### PR TITLE
Add QEMU virt UART print utility

### DIFF
--- a/test/common/linx_print.h
+++ b/test/common/linx_print.h
@@ -1,0 +1,33 @@
+#ifndef LINX_PRINT_H
+#define LINX_PRINT_H
+
+/*
+ * Minimal print utility for QEMU virt (UART @ 0x10000000).
+ * No syscalls, no buffering — direct MMIO writes.
+ * Works with both freestanding (-nostdlib) and hosted builds.
+ */
+
+#define LINX_VIRT_UART_BASE 0x10000000u
+
+static inline void linx_putc(char c)
+{
+    volatile unsigned char *uart = (volatile unsigned char *)LINX_VIRT_UART_BASE;
+    *uart = (unsigned char)c;
+}
+
+static inline void linx_puts(const char *s)
+{
+    while (*s) {
+        linx_putc(*s++);
+    }
+    linx_putc('\n');
+}
+
+static inline void linx_print(const char *s)
+{
+    while (*s) {
+        linx_putc(*s++);
+    }
+}
+
+#endif /* LINX_PRINT_H */


### PR DESCRIPTION
Closes #8

Header-only `linx_print.h` in `test/common/` providing direct-to-UART print helpers for QEMU virt:

- `linx_putc(c)`: write one char to `0x10000000`
- `linx_puts(s)`: write string + newline
- `linx_print(s)`: write string without newline

**Why:** SuperNPUBench programs currently print via `TUBE_ADDRESS` (`0x13000000`, GFSIM tube), which is invisible under `qemu-system-linx64` (virt UART at `0x10000000`). This header fills that gap so programs can produce visible output in QEMU without syscalls or buffering.

**Usage:**
```c
#include "linx_print.h"
linx_puts("Hello, World!");
```

No link dependencies — inline, works in both freestanding (`-nostdlib`) and hosted builds.
