### PR TITLE
feat(moe): add four-PE multi_thread moe_dispatch_mt / moe_combine_mt kernels

### DIFF
--- a/benchmark/one-level-arch/kernels/moe_combine_mt/moe_combine_mt.hpp
+++ b/benchmark/one-level-arch/kernels/moe_combine_mt/moe_combine_mt.hpp
@@ -1,0 +1,291 @@
+#ifndef SUPERNPU_MOE_COMBINE_MT_HPP
+#define SUPERNPU_MOE_COMBINE_MT_HPP
+#include <common/pto_tileop.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace supernpu::tile_isa {
+
+// ============================================================================
+// MoE Combine — Multi-thread 4-PE SPMD variant
+//
+// This is the four-PE version of kernels/moe_combine/moe_combine_v2.hpp.
+// The operator semantics are unchanged (pack expert outputs into
+// per-(token, topk) window slots, then reduce scale-weighted rows into out);
+// only the execution is partitioned across PEs with get_thread_idx():
+//
+//   Phase 1  combine_pack_mt    PE tid owns expanded rows [tid*rowsPerPE,
+//                                (tid+1)*rowsPerPE). expandIdx rows are
+//                                read PE-disjoint; window/flag writes are
+//                                PE-disjoint provided expandIdx maps to
+//                                distinct slots (dispatch-stage contract).
+//   Phase 2  combine_reduce_mt  PE tid owns tokens [tid*tokensPerPE,
+//                                (tid+1)*tokensPerPE). Reads the K window
+//                                slots of its own tokens (written by any PE
+//                                in Phase 1 — covered by the phase barrier),
+//                                accumulates in fp32, writes its own out
+//                                rows and clears its own slots' flags.
+//
+// Tile rules (established toolchain contract, see kernels/group_token_vec_mt
+// and kernels/moe_dispatch_mt):
+//   1. Every TLOAD result is consumed by tile ops (TSUB sync stand-in,
+//      TCVT/TMULS/TADD compute) and leaves the tile domain via TSTORE;
+//      scalar reads hit GM.
+//   2. Per-PE tiles are disjoint — no duplicated TLOAD traffic.
+//   3. TCMP is unavailable on this toolchain; flag checks stay tile
+//      pass-throughs exactly as in the single-PE version.
+//   4. Cross-PE hand-offs are guarded by combineMtBarrier.
+// ============================================================================
+
+constexpr int kCombineMtThreads = 4;
+
+// Multi-PE barrier: volatile per-PE phase flags + compiler memory barrier,
+// same convention as kernels/group_token_vec_mt/group_token_vec_mt.hpp.
+static volatile uint32_t sCombineMtPhaseDone[kCombineMtThreads];
+
+static inline void combineMtCompilerBarrier()
+{
+    __asm__ volatile("" : : : "memory");
+}
+
+static inline void combineMtBarrier(uint32_t phase)
+{
+    combineMtCompilerBarrier();
+    sCombineMtPhaseDone[get_thread_idx()] = phase;
+    combineMtCompilerBarrier();
+    for (int t = 0; t < kCombineMtThreads; ++t) {
+        while (sCombineMtPhaseDone[t] < phase) {
+        }
+    }
+    combineMtCompilerBarrier();
+}
+
+// ====== Phase 1: Pack (PE tid owns expanded rows [tid*rowsPerPE, +rowsPerPE)) ======
+template <typename DType, int NumExpanded, int H, int K, int TileW>
+void combine_pack_mt(DType* expandX, int32_t* expandIdx,
+                     DType* windowData, float* windowFlag)
+{
+    constexpr int kTiles = H / TileW;
+    constexpr int rowsPerPE = NumExpanded / kCombineMtThreads;
+    const int tid = static_cast<int>(get_thread_idx());
+    using namespace pto;
+
+    using gm_x    = global_tensor<DType, RowMajor<NumExpanded, H>>;
+    using gm_win  = global_tensor<DType, RowMajor<NumExpanded, H>>;
+    using gm_flag = global_tensor<float,   RowMajor<NumExpanded, TileW>>;
+    using tile_d  = Tile<Location::Vec, DType, 1, TileW, BLayout::RowMajor>;
+    using tile_f  = Tile<Location::Vec, float,  1, TileW, BLayout::RowMajor>;
+    using it_x    = global_iterator<gm_x,    tile_d>;
+    using it_win  = global_iterator<gm_win,  tile_d>;
+    using it_flag = global_iterator<gm_flag, tile_f>;
+
+    // Full-tensor iterators; each PE addresses its own expanded-row range so
+    // the per-PE tiles are disjoint (rule 2).
+    it_x    x_iter(expandX);
+    it_win  win_iter(windowData);
+    it_flag flag_iter(windowFlag);
+
+    for (int tk = tid * rowsPerPE; tk < (tid + 1) * rowsPerPE; tk++) {
+        int tokenId = expandIdx[tk * 3 + 1];
+        int topkId  = expandIdx[tk * 3 + 2];
+        int slot    = tokenId * K + topkId;
+
+        for (int t = 0; t < kTiles; t++) {
+            tile_d xq;
+            auto gx = x_iter(tk, t);
+            TLOAD(xq, gx);
+
+            // #3 Pipeline sync (SyncFunc<MTE2_V> aligned)
+            // TSUB(dst, src, src) is a compile-time stand-in for TMOV(dst, src):
+            // the 0828 toolchain's asm matcher rejects TMOV's 0.58.4 B.DATR
+            // syntax ("NORM, DTYPE_NONE, Zero"); TSUB emits no B.DATR and keeps
+            // the same src->dst dependency edge (dst = src - src = 0).
+            tile_d sync_d;
+            TSUB(sync_d, xq, xq);
+
+            auto gw = win_iter(slot, t);
+            TSTORE(gw, xq);
+
+            // #1 Flag fill: data ready marker (TEXPANDS + TSTORE)
+            tile_f flagTile;
+            TEXPANDS(flagTile, 1.0f);
+
+            auto gf = flag_iter(slot, t);
+            TSTORE(gf, flagTile);
+        }
+    }
+}
+
+// ====== #4 Flag check (tile pass-through; TCMP's 0.58.4 B.DATR syntax is
+// rejected by the 0828 toolchain asm matcher, so the EQ predicate collapses
+// to a flag->predBuf copy. predBuf consumers treat non-1.0f as "not ready";
+// the flag is 1.0f after pack, so pass-through preserves the wait semantics.
+// TSUB stands in for the removed TMOV sync, see combine_pack_mt note) ======
+template <int NumExpanded, int TileW>
+void combine_check_flag_mt(float* windowFlag, float* predBuf, int slot, int t)
+{
+    using namespace pto;
+    using gm_flag = global_tensor<float, RowMajor<NumExpanded, TileW>>;
+    using gm_pred = global_tensor<float, RowMajor<NumExpanded, TileW>>;
+    using tile_f  = Tile<Location::Vec, float, 1, TileW, BLayout::RowMajor>;
+    using it_flag = global_iterator<gm_flag, tile_f>;
+    using it_pred = global_iterator<gm_pred, tile_f>;
+
+    it_flag flag_iter(windowFlag);
+    it_pred pred_iter(predBuf);
+
+    tile_f flagTile;
+    auto gf = flag_iter(slot, t);
+    TLOAD(flagTile, gf);
+
+    // #3 Pipeline sync (SyncFunc<MTE2_V> aligned)
+    tile_f sync_f1;
+    TSUB(sync_f1, flagTile, flagTile);
+
+    auto gp = pred_iter(slot, t);
+    TSTORE(gp, flagTile);
+}
+
+// ====== #1 Clear flag ======
+template <int NumExpanded, int TileW>
+void combine_clear_flag_mt(float* windowFlag, int slot)
+{
+    using namespace pto;
+    using gm_flag = global_tensor<float, RowMajor<NumExpanded, TileW>>;
+    using tile_f  = Tile<Location::Vec, float, 1, TileW, BLayout::RowMajor>;
+    using it_flag = global_iterator<gm_flag, tile_f>;
+    it_flag flag_iter(windowFlag);
+
+    tile_f zeroFlag;
+    TEXPANDS(zeroFlag, 0.0f);
+
+    // TSUB as TMOV stand-in (see combine_pack_mt note).
+    tile_f sync_zf;
+    TSUB(sync_zf, zeroFlag, zeroFlag);
+
+    auto gf = flag_iter(slot, 0);
+    TSTORE(gf, zeroFlag);
+}
+
+// ====== Phase 2: Reduce (PE tid owns tokens [tid*tokensPerPE, +tokensPerPE)) ======
+// Reads this PE's tokens' K window slots (written by any PE in Phase 1 —
+// the caller guarantees the phase-1 barrier has completed), accumulates
+// scale-weighted rows in fp32, writes PE-disjoint out rows, clears flags.
+template <typename DTypeIn, typename DTypeOut, int BS, int H, int K,
+          int NumExpanded, int TileW>
+void combine_reduce_mt(float* expertScales, DTypeIn* windowData, float* windowFlag,
+                       float* predBuf, DTypeOut* out)
+{
+    constexpr int kTiles = H / TileW;
+    constexpr int tokensPerPE = BS / kCombineMtThreads;
+    const int tid = static_cast<int>(get_thread_idx());
+    using namespace pto;
+
+    using gm_win  = global_tensor<DTypeIn,  RowMajor<NumExpanded, H>>;
+    using gm_out  = global_tensor<DTypeOut, RowMajor<BS, H>>;
+    using tile_d  = Tile<Location::Vec, DTypeIn,  1, TileW, BLayout::RowMajor>;
+    using tile_f  = Tile<Location::Vec, float,    1, TileW, BLayout::RowMajor>;
+    using tile_o  = Tile<Location::Vec, DTypeOut, 1, TileW, BLayout::RowMajor>;
+    using it_win  = global_iterator<gm_win,  tile_d>;
+    using it_out  = global_iterator<gm_out,  tile_o>;
+
+    it_win  win_iter(windowData);
+    it_out  out_iter(out);
+
+    for (int n = tid * tokensPerPE; n < (tid + 1) * tokensPerPE; n++) {
+        for (int t = 0; t < kTiles; t++) {
+            // #4 Flag check (tile pass-through; TCMP unavailable on 0828)
+            // Scalar readback skipped — barrier-covered data always ready
+            for (int k = 0; k < K; k++) {
+                combine_check_flag_mt<NumExpanded, TileW>(windowFlag, predBuf, n * K + k, t);
+            }
+
+            // Flag wait (scalar readback of predBuf)
+            for (int k = 0; k < K; k++) {
+                int slot = n * K + k;
+                if (predBuf[slot * TileW] < 0.5f) break;
+            }
+
+            tile_f acc;
+            TEXPANDS(acc, 0.0f);
+
+            for (int k = 0; k < K; k++) {
+                int slot = n * K + k;
+                float scale = expertScales[n * K + k];
+
+                tile_d xq;
+                auto gw = win_iter(slot, t);
+                TLOAD(xq, gw);
+
+                // #3 Pipeline sync (SyncFunc<MTE2_V> aligned)
+                // TSUB as TMOV stand-in (see combine_pack_mt note).
+                tile_d sync_d;
+                TSUB(sync_d, xq, xq);
+
+                tile_f xf;
+                TCVT(xf, xq);
+                TMULS(xf, xf, scale);
+                TADD(acc, acc, xf);
+            }
+
+            tile_o oq;
+            TCVT(oq, acc);
+            auto gout = out_iter(n, t);
+            TSTORE(gout, oq);
+        }
+
+        // #1 Clear flag (TEXPANDS(0.0) + TSTORE)
+        for (int k = 0; k < K; k++) {
+            combine_clear_flag_mt<NumExpanded, TileW>(windowFlag, n * K + k);
+        }
+    }
+}
+
+// ====== Main entry (multi-PE SPMD; called by every PE) ======
+// Cross-PE hand-offs separated by combineMtBarrier:
+//   barrier(1): all PEs' pack writes (windowData/windowFlag) visible before
+//               any PE's reduce reads another PE's slots
+//   barrier(2): all out rows written and flags cleared before any PE leaves
+template <typename DTypeIn, typename DTypeOut, int BS, int H, int K,
+          int NumExpanded, int TileW = 128>
+void moe_combine_mt(DTypeIn* expandX, float* expertScales,
+                    int32_t* expandIdx,
+                    DTypeIn* windowData, float* windowFlag,
+                    uint32_t* windowState, float* predBuf,
+                    DTypeOut* out)
+{
+    static_assert(BS > 0 && H > 0 && K > 0 && NumExpanded > 0, "dim must be positive");
+    static_assert(TileW % 8 == 0, "TileW must be multiple of 8");
+    static_assert(NumExpanded % kCombineMtThreads == 0,
+                  "NumExpanded must be divisible by the 4 PEs");
+    static_assert(BS % kCombineMtThreads == 0,
+                  "BS must be divisible by the 4 PEs");
+    const int tid = static_cast<int>(get_thread_idx());
+
+    // #5 Window State Init (InitWinState aligned) — PE0 only
+    if (tid == 0) {
+        uint32_t dataState = windowState[0];
+        windowState[0] = (dataState == 0) ? 1 : 0;
+        windowState[1] = 1;
+        windowState[2] = 0;
+    }
+
+    // ====== Phase 1: Pack (expandX → window + flag) ======
+    combine_pack_mt<DTypeIn, NumExpanded, H, K, TileW>(
+        expandX, expandIdx, windowData, windowFlag);
+    combineMtBarrier(1);
+
+    // ====== Phase 2: Reduce (window → weighted sum → out) ======
+    combine_reduce_mt<DTypeIn, DTypeOut, BS, H, K, NumExpanded, TileW>(
+        expertScales, windowData, windowFlag, predBuf, out);
+    combineMtBarrier(2);
+
+    // Window state writeback — PE0 only
+    if (tid == 0) {
+        windowState[4] = BS;
+    }
+}
+
+} // namespace supernpu::tile_isa
+#endif

--- a/benchmark/one-level-arch/kernels/moe_dispatch_mt/moe_dispatch_mt.hpp
+++ b/benchmark/one-level-arch/kernels/moe_dispatch_mt/moe_dispatch_mt.hpp
@@ -1,0 +1,385 @@
+#ifndef SUPERNPU_MOE_DISPATCH_MT_HPP
+#define SUPERNPU_MOE_DISPATCH_MT_HPP
+#include <common/pto_tileop.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace supernpu::tile_isa {
+
+// ============================================================================
+// MoE Dispatch — Multi-thread 4-PE SPMD variant
+//
+// This is the four-PE version of kernels/moe_dispatch/moe_dispatch_v2.hpp.
+// The operator semantics are unchanged (pack x into 512B-stride window slots,
+// per-expert cumsum, expert-major copy-out into continuous expandXOut); only
+// the execution is partitioned across PEs with get_thread_idx():
+//
+//   Phase 1  dispatch_pack_mt   PE tid owns slots [tid*slotsPerPE,
+//                               (tid+1)*slotsPerPE). x rows, window rows,
+//                               flags and triples are all PE-disjoint.
+//   Phase 2  cal_cumsum_mt      per-PE local histogram over own slots,
+//                               cross-PE reduce; each PE writes its assigned
+//                               expert range of sendCountsOut /
+//                               expertTokenNumsOut / expertStarts.
+//   Phase 3  dispatch_copyout_mt PE tid re-emits its own slots at exactly the
+//                               expert-major position the single-PE version
+//                               produces: dstPos = expertStarts[eid] + rank of
+//                               the slot inside its expert group. Output rows
+//                               are a permutation, hence PE-disjoint.
+//
+// Tile rules (established toolchain contract, see kernels/group_token_vec_mt):
+//   1. Every TLOAD result is consumed by tile ops (TSUB sync stand-in) and
+//      leaves the tile domain via TSTORE; scalar reads hit GM.
+//   2. Per-PE tiles are disjoint — no duplicated TLOAD traffic.
+//   3. TCMP is unavailable on this toolchain; flag checks stay tile
+//      pass-throughs exactly as in the single-PE version.
+//   4. Cross-PE hand-offs are guarded by mtBarrier.
+// ============================================================================
+
+constexpr int kMtThreadsPerBlock = 4;
+
+// Multi-PE barrier: volatile per-PE phase flags + compiler memory barrier,
+// same convention as kernels/group_token_vec_mt/group_token_vec_mt.hpp.
+static volatile uint32_t sMtPhaseDone[kMtThreadsPerBlock];
+
+static inline void mtCompilerBarrier()
+{
+    __asm__ volatile("" : : : "memory");
+}
+
+static inline void mtBarrier(uint32_t phase)
+{
+    mtCompilerBarrier();
+    sMtPhaseDone[get_thread_idx()] = phase;
+    mtCompilerBarrier();
+    for (int t = 0; t < kMtThreadsPerBlock; ++t) {
+        while (sMtPhaseDone[t] < phase) {
+        }
+    }
+    mtCompilerBarrier();
+}
+
+// ====== Phase 1: Pack (PE tid owns slots [tid*slotsPerPE, +slotsPerPE)) ======
+template <typename DType, int BS, int H, int K, int MoeExpertNum, int TileW,
+          int WindowStride>
+void dispatch_pack_mt(DType* x, int32_t* expertIds, int32_t* windowTriple,
+                      DType* windowData, float* windowFlag)
+{
+    constexpr int slotCount = BS * K;
+    constexpr int hTiles = H / TileW;
+    constexpr int slotsPerPE = slotCount / kMtThreadsPerBlock;
+    const int tid = static_cast<int>(get_thread_idx());
+    using namespace pto;
+
+    using gm_x    = global_tensor<DType, RowMajor<BS, H>>;
+    using gm_w    = global_tensor<DType, RowMajor<slotCount, WindowStride>>;
+    using gm_flag = global_tensor<float,   RowMajor<slotCount, TileW>>;
+    using tile_d  = Tile<Location::Vec, DType, 1, TileW, BLayout::RowMajor>;
+    using tile_f  = Tile<Location::Vec, float,  1, TileW, BLayout::RowMajor>;
+    using it_x    = global_iterator<gm_x,    tile_d>;
+    using it_w    = global_iterator<gm_w,    tile_d>;
+    using it_flag = global_iterator<gm_flag, tile_f>;
+
+    // Full-tensor iterators; each PE addresses its own slot range so the
+    // per-PE tiles are disjoint (rule 2).
+    it_x    x_iter(x);
+    it_w    w_iter(windowData);
+    it_flag flag_iter(windowFlag);
+
+    for (int tk = tid * slotsPerPE; tk < (tid + 1) * slotsPerPE; tk++) {
+        int tokenId = tk / K;
+        int topkId  = tk % K;
+
+        for (int t = 0; t < hTiles; t++) {
+            tile_d xq;
+            auto gx = x_iter(tokenId, t);
+            TLOAD(xq, gx);
+
+            // Pipeline sync (SyncFunc<MTE2_V> aligned); TSUB as TMOV
+            // stand-in (see moe_dispatch_v2.hpp note).
+            tile_d sync_d;
+            TSUB(sync_d, xq, xq);
+
+            // 512B stride write: data at [tk*WindowStride + t*TileW]
+            auto gw = w_iter(tk, t);
+            TSTORE(gw, xq);
+        }
+
+        // 512B block packing: flag fill (TEXPANDS + TSTORE)
+        tile_f flagTile;
+        TEXPANDS(flagTile, 1.0f);
+
+        // Pipeline sync (SyncFunc<V_MTE3> aligned); TSUB as TMOV stand-in.
+        tile_f sync_f;
+        TSUB(sync_f, flagTile, flagTile);
+
+        auto gf = flag_iter(tk, 0);
+        TSTORE(gf, flagTile);
+
+        // FillTriple (scalar, 12B — too small for tile)
+        windowTriple[tk * 3 + 0] = 0;
+        windowTriple[tk * 3 + 1] = tokenId;
+        windowTriple[tk * 3 + 2] = topkId;
+    }
+}
+
+// ====== Phase 2: CalCumSum (per-PE histogram + cross-PE reduce) ======
+// cntLocal layout: [pe * MoeExpertNum + expert]. After the phase-1 barrier
+// every PE reduces its assigned expert range; expertStarts[e] holds the
+// exclusive prefix (number of slots owned by experts < e), which Phase 3
+// uses to reproduce the single-PE expert-major output order.
+template <int BS, int K, int MoeExpertNum>
+void cal_cumsum_mt(int32_t* expertIds, int32_t* sendCountsOut,
+                   int64_t* expertTokenNumsOut, int32_t* cntLocal,
+                   int32_t* expertStarts)
+{
+    constexpr int slotCount = BS * K;
+    constexpr int slotsPerPE = slotCount / kMtThreadsPerBlock;
+    constexpr int expertsPerPE = MoeExpertNum / kMtThreadsPerBlock;
+    const int tid = static_cast<int>(get_thread_idx());
+
+    // Per-PE local histogram over this PE's own slots (scalar GM reads)
+    int32_t* myCnt = cntLocal + tid * MoeExpertNum;
+    for (int e = 0; e < MoeExpertNum; e++) {
+        myCnt[e] = 0;
+    }
+    for (int i = tid * slotsPerPE; i < (tid + 1) * slotsPerPE; i++) {
+        int32_t eid = expertIds[i];
+        if (eid >= 0 && eid < MoeExpertNum) myCnt[eid]++;
+    }
+
+    // Reduce: each PE writes its assigned expert range (needs every PE's
+    // cntLocal — caller guarantees the phase-1 barrier has completed)
+    for (int e = 0; e < expertsPerPE; e++) {
+        int ge = tid * expertsPerPE + e;
+        int32_t sum = 0;
+        int32_t before = 0;
+        for (int e2 = 0; e2 <= ge; e2++) {
+            for (int t = 0; t < kMtThreadsPerBlock; t++) {
+                int32_t c = cntLocal[t * MoeExpertNum + e2];
+                if (e2 == ge) sum += c; else before += c;
+            }
+        }
+        expertTokenNumsOut[ge] = sum;
+        sendCountsOut[ge] = before + sum;   // inclusive cumsum (v2 semantics)
+        expertStarts[ge] = before;          // exclusive start for Phase 3
+    }
+}
+
+// ====== CUMSUM flag write (PE0 only; TEXPANDS + TSTORE at windowState+4) ======
+template <int TileW>
+void write_cumsum_flag(uint32_t* windowState)
+{
+    using namespace pto;
+    using tile_f = Tile<Location::Vec, float, 1, TileW, BLayout::RowMajor>;
+    tile_f cumsumFlag;
+    TEXPANDS(cumsumFlag, 1.0f);
+
+    // TSUB as TMOV stand-in (see moe_dispatch_v2.hpp note).
+    tile_f sync_cf;
+    TSUB(sync_cf, cumsumFlag, cumsumFlag);
+
+    using gm_st = global_tensor<float, RowMajor<1, TileW>>;
+    auto gs = reinterpret_cast<gm_st*>(windowState + 4);
+    TSTORE(*gs, cumsumFlag);
+}
+
+// ====== Flag check (tile pass-through; TCMP unavailable on the 0828
+// toolchain — see moe_dispatch_v2.hpp note. predBuf is never read back) ======
+template <int BS, int K, int TileW>
+void check_flag_mt(float* windowFlag, float* predBuf, int srcSlot)
+{
+    constexpr int slotCount = BS * K;
+    using namespace pto;
+    using gm_flag = global_tensor<float, RowMajor<slotCount, TileW>>;
+    using gm_pred = global_tensor<float, RowMajor<slotCount, TileW>>;
+    using tile_f  = Tile<Location::Vec, float, 1, TileW, BLayout::RowMajor>;
+    using it_flag = global_iterator<gm_flag, tile_f>;
+    using it_pred = global_iterator<gm_pred, tile_f>;
+
+    it_flag flag_iter(windowFlag);
+    it_pred pred_iter(predBuf);
+
+    tile_f flagTile;
+    auto gf = flag_iter(srcSlot, 0);
+    TLOAD(flagTile, gf);
+
+    // Pipeline sync (SyncFunc<MTE2_V> aligned)
+    tile_f sync_f1;
+    TSUB(sync_f1, flagTile, flagTile);
+
+    auto gp = pred_iter(srcSlot, 0);
+    TSTORE(gp, flagTile);
+}
+
+// ====== CUMSUM flag check (tile pass-through, PE0 only) ======
+template <int TileW>
+void check_cumsum_flag_mt(uint32_t* windowState, float* predBuf)
+{
+    using namespace pto;
+    using gm_st  = global_tensor<float, RowMajor<1, TileW>>;
+    using gm_pred = global_tensor<float, RowMajor<1, TileW>>;
+    using tile_f = Tile<Location::Vec, float, 1, TileW, BLayout::RowMajor>;
+    using it_pred = global_iterator<gm_pred, tile_f>;
+
+    auto gs = reinterpret_cast<gm_st*>(windowState + 4);
+    it_pred pred_iter(predBuf);
+
+    tile_f readFlag;
+    TLOAD(readFlag, *gs);
+
+    // Pipeline sync (SyncFunc<MTE2_V> aligned)
+    tile_f sync_f1;
+    TSUB(sync_f1, readFlag, readFlag);
+
+    auto gp = pred_iter(0, 0);
+    TSTORE(gp, readFlag);
+}
+
+// ====== Clear flag ======
+template <int BS, int K, int TileW>
+void clear_flag_mt(float* windowFlag, int srcSlot)
+{
+    constexpr int slotCount = BS * K;
+    using namespace pto;
+    using gm_flag = global_tensor<float, RowMajor<slotCount, TileW>>;
+    using tile_f  = Tile<Location::Vec, float, 1, TileW, BLayout::RowMajor>;
+    using it_flag = global_iterator<gm_flag, tile_f>;
+    it_flag flag_iter(windowFlag);
+
+    tile_f zeroFlag;
+    TEXPANDS(zeroFlag, 0.0f);
+
+    // TSUB as TMOV stand-in (see moe_dispatch_v2.hpp note).
+    tile_f sync_zf;
+    TSUB(sync_zf, zeroFlag, zeroFlag);
+
+    auto gf = flag_iter(srcSlot, 0);
+    TSTORE(gf, zeroFlag);
+}
+
+// ====== Phase 3: Read data from window → expandXOut (PE-disjoint rows) ======
+template <typename DType, int BS, int H, int K, int TileW, int WindowStride>
+void dispatch_copy_out_mt(DType* windowData, DType* expandXOut,
+                          int32_t srcSlot, int dstPos)
+{
+    constexpr int hTiles = H / TileW;
+    using namespace pto;
+
+    using gm_w   = global_tensor<DType, RowMajor<BS * K, WindowStride>>;
+    using gm_out = global_tensor<DType, RowMajor<BS * K, H>>;
+    using tile_d = Tile<Location::Vec, DType, 1, TileW, BLayout::RowMajor>;
+    using it_w   = global_iterator<gm_w,   tile_d>;
+    using it_out = global_iterator<gm_out, tile_d>;
+
+    it_w   w_iter(windowData);
+    it_out out_iter(expandXOut);
+
+    for (int t = 0; t < hTiles; t++) {
+        tile_d xq;
+        auto gw = w_iter(srcSlot, t);
+        TLOAD(xq, gw);
+
+        // Pipeline sync (SyncFunc<MTE2_V> aligned)
+        tile_d sync_d;
+        TSUB(sync_d, xq, xq);
+
+        auto gout = out_iter(dstPos, t);
+        TSTORE(gout, xq);
+    }
+}
+
+// ====== Main entry (multi-PE SPMD; called by every PE) ======
+// Cross-PE hand-offs separated by mtBarrier:
+//   barrier(1): all PEs' pack writes (windowData/flag/triple) visible before
+//               the histogram reduce and the Phase-3 reads
+//   barrier(2): expertStarts + PE0's cumsum flag visible before Phase 3
+//   barrier(3): all outputs fully written before any PE leaves the kernel
+// cntLocal needs kMtThreadsPerBlock * MoeExpertNum int32 words,
+// expertStarts needs MoeExpertNum int32 words of scratch GM.
+template <typename DType, int BS, int H, int K, int MoeExpertNum, int TileW = 128,
+          int WindowStride = 256>
+void moe_dispatch_mt(
+    DType* x, int32_t* expertIds, float* expertScales,
+    DType* expandXOut, int32_t* expandIdxOut, float* expandScalesOut,
+    int32_t* sendCountsOut, int64_t* expertTokenNumsOut,
+    DType* windowData, float* windowFlag, float* predBuf,
+    int32_t* windowTriple, uint32_t* windowState, DType* outBuf,
+    int32_t* cntLocal, int32_t* expertStarts)
+{
+    constexpr int slotCount = BS * K;
+    constexpr int slotsPerPE = slotCount / kMtThreadsPerBlock;
+    static_assert(slotCount % kMtThreadsPerBlock == 0,
+                  "slotCount (BS*K) must be divisible by the 4 PEs");
+    static_assert(MoeExpertNum % kMtThreadsPerBlock == 0,
+                  "MoeExpertNum must be divisible by the 4 PEs");
+    const int tid = static_cast<int>(get_thread_idx());
+
+    // Window State Init (InitWinState aligned) — PE0 only
+    if (tid == 0) {
+        uint32_t dataState = windowState[0];
+        windowState[0] = (dataState == 0) ? 1 : 0;
+        windowState[1] = 1;
+        windowState[2] = 0;
+    }
+
+    // ====== Phase 1: AllToAllDispatch (pack x → window + flag) ======
+    dispatch_pack_mt<DType, BS, H, K, MoeExpertNum, TileW, WindowStride>(
+        x, expertIds, windowTriple, windowData, windowFlag);
+    mtBarrier(1);
+
+    // ====== Phase 2: CalCumSum (count + cumsum) ======
+    cal_cumsum_mt<BS, K, MoeExpertNum>(expertIds, sendCountsOut,
+                                        expertTokenNumsOut, cntLocal,
+                                        expertStarts);
+
+    // CUMSUM soft sync + flag check — PE0 only (same PE writes then reads)
+    if (tid == 0) {
+        write_cumsum_flag<TileW>(windowState);
+        check_cumsum_flag_mt<TileW>(windowState, predBuf);
+    }
+    mtBarrier(2);
+
+    // ====== Phase 3: LocalWindowCopy (read window → continuous output) ======
+    // Each PE re-emits its own slots at the expert-major position the
+    // single-PE version produces: dstPos = expertStarts[eid] + rank of the
+    // slot among the slots of the same expert. expertIds is a read-only
+    // input, so the rank scan needs no extra synchronization; the window /
+    // triple reads are covered by barrier(1) and expertStarts by barrier(2).
+    for (int i = tid * slotsPerPE; i < (tid + 1) * slotsPerPE; i++) {
+        int32_t eid = expertIds[i];
+        if (eid < 0 || eid >= MoeExpertNum) continue;
+
+        int32_t rank = 0;
+        for (int j = 0; j < i; j++) {
+            if (expertIds[j] == eid) rank++;
+        }
+        int32_t dstPos = expertStarts[eid] + rank;
+
+        // Flag check (tile pass-through; TCMP unavailable on 0828)
+        check_flag_mt<BS, K, TileW>(windowFlag, predBuf, i);
+
+        // Read data from window → expandXOut (tile copy, 512B stride)
+        dispatch_copy_out_mt<DType, BS, H, K, TileW, WindowStride>(
+            windowData, expandXOut, i, dstPos);
+
+        // Read triple + scale (scalar)
+        expandIdxOut[dstPos * 3 + 0] = windowTriple[i * 3 + 0];
+        expandIdxOut[dstPos * 3 + 1] = windowTriple[i * 3 + 1];
+        expandIdxOut[dstPos * 3 + 2] = windowTriple[i * 3 + 2];
+        expandScalesOut[dstPos] = expertScales[i];
+
+        // Clear flag (TEXPANDS(0.0) + TSTORE)
+        clear_flag_mt<BS, K, TileW>(windowFlag, i);
+    }
+    mtBarrier(3);
+
+    // Window state writeback — PE0 only
+    if (tid == 0) {
+        windowState[4] = BS;
+    }
+}
+
+} // namespace supernpu::tile_isa
+#endif

--- a/benchmark/one-level-arch/test/kernel/multi_thread/moe_combine/Makefile
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/moe_combine/Makefile
@@ -1,0 +1,3 @@
+TARGET = $(ELF_DIR)/moe_combine_mt.elf
+SRC_FILE += $(TEST_ROOT)/$(CASE_SRC_DIR)/$(TESTCASE).cpp
+include ../../../common/Makefile.common

--- a/benchmark/one-level-arch/test/kernel/multi_thread/moe_combine/compile.all
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/moe_combine/compile.all
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Multi-thread (4-PE SPMD) MoE Combine compile test.
+# Run the ELF with: gfrun -t 1 -s softcore.multiThreadNum=4 -f <elf>
+
+: "${COMPILER_DIR:?Set COMPILER_DIR to the in-repo Linx compiler bin directory}"
+
+make TESTCASE=moe_combine_mt COMPILER_DIR=$COMPILER_DIR

--- a/benchmark/one-level-arch/test/kernel/multi_thread/moe_combine/src/moe_combine_mt.cpp
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/moe_combine/src/moe_combine_mt.cpp
@@ -1,0 +1,125 @@
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+#include <cmath>
+#include <cstring>
+#include "benchmark.h"
+#include "moe_combine_mt/moe_combine_mt.hpp"
+
+using namespace supernpu::tile_isa;
+
+using dtype = __bf16;
+
+constexpr int BS = 8;
+constexpr int H = 128;
+constexpr int K = 4;
+constexpr int NUM_EXPANDED = BS * K;
+constexpr int TILE_W = 128;
+
+static dtype expand_x[NUM_EXPANDED * H] __attribute__((aligned(4096))) = {};
+static float expert_scales[NUM_EXPANDED * TILE_W] __attribute__((aligned(4096))) = {};
+static int32_t expand_idx[NUM_EXPANDED * 3] __attribute__((aligned(4096))) = {};
+static dtype window_data[NUM_EXPANDED * H] __attribute__((aligned(4096))) = {};
+static float window_flag[NUM_EXPANDED * TILE_W] __attribute__((aligned(4096))) = {};
+static uint32_t window_state[16] __attribute__((aligned(4096))) = {};
+static float pred_buf[NUM_EXPANDED * TILE_W] __attribute__((aligned(4096))) = {};
+static dtype out_buf[BS * H] __attribute__((aligned(4096))) = {};
+
+// Keeps the non-leader park loop side-effecting so -O2 cannot drop it.
+static volatile uint32_t sParkSink = 0;
+
+static inline float bf16ToF32(uint16_t raw)
+{
+    uint32_t full = static_cast<uint32_t>(raw) << 16;
+    float v;
+    std::memcpy(&v, &full, 4);
+    return v;
+}
+
+// Round-to-nearest-even fp32 -> bf16 bits (TCVT rounding contract).
+static inline uint16_t f32ToBf16Bits(float v)
+{
+    uint32_t bits;
+    std::memcpy(&bits, &v, 4);
+    uint32_t lsb = (bits >> 16) & 1u;
+    bits += 0x7fffu + lsb;
+    return static_cast<uint16_t>(bits >> 16);
+}
+
+int main() {
+    const uint32_t tid = get_thread_idx();
+
+    // Input init runs redundantly on every PE (deterministic, identical
+    // writes — same convention as group_token_vec_mt), so no extra barrier
+    // is needed before the kernel reads expandX / expandIdx / expertScales.
+    for (int i = 0; i < NUM_EXPANDED * H; i++) {
+        float fval = static_cast<float>(i) * 0.1f;
+        uint32_t bits; std::memcpy(&bits, &fval, 4);
+        uint16_t raw = (uint16_t)(bits >> 16);
+        std::memcpy(&expand_x[i], &raw, 2);
+    }
+    for (int tk = 0; tk < NUM_EXPANDED; tk++) {
+        expand_idx[tk * 3 + 0] = 0;
+        expand_idx[tk * 3 + 1] = tk / K;
+        expand_idx[tk * 3 + 2] = tk % K;
+    }
+    // The kernel reads expertScales densely at [n*K + k]; fill the dense
+    // prefix so every slot carries a real weight.
+    for (int i = 0; i < NUM_EXPANDED; i++) {
+        expert_scales[i] = 0.25f;
+    }
+
+    BENCHSTART;
+
+    moe_combine_mt<dtype, dtype, BS, H, K, NUM_EXPANDED, TILE_W>(
+        expand_x, expert_scales, expand_idx, window_data, window_flag,
+        window_state, pred_buf, out_buf);
+
+    BENCHEND;
+
+    // Verification runs on PE0 only (all outputs are visible after the
+    // kernel's final barrier). Non-leader PEs park: a worker reaching _end
+    // first raises exit_group and would truncate PE0's verification mid-way
+    // (the leader's exit ends the parked workers instead).
+    if (tid != 0) {
+        for (;;) {
+            sParkSink = tid;
+        }
+    }
+
+    // 1. out rows == fp32 scale-weighted sum of the K window slots,
+    //    converted to bf16 (kernel accumulates in fp32 via TCVT/TMULS/TADD,
+    //    then TCVT back; allow the last mantissa bit to round either way).
+    for (int n = 0; n < BS; n++) {
+        for (int j = 0; j < H; j++) {
+            float acc = 0.0f;
+            for (int k = 0; k < K; k++) {
+                uint16_t raw;
+                std::memcpy(&raw, &expand_x[(n * K + k) * H + j], 2);
+                acc += expert_scales[n * K + k] * bf16ToF32(raw);
+            }
+            uint16_t expBits = f32ToBf16Bits(acc);
+            uint16_t actBits;
+            std::memcpy(&actBits, &out_buf[n * H + j], 2);
+            uint16_t diff = expBits ^ actBits;
+            if (diff != 0 && diff != 1) return 1;
+        }
+    }
+
+    // 2. window flags all cleared by the reduce stage
+    for (int i = 0; i < NUM_EXPANDED * TILE_W; i++) {
+        if (window_flag[i] != 0.0f) return 2;
+    }
+
+    // 3. window state: toggle 0 -> 1, run flags, token-count writeback
+    if (window_state[0] != 1u || window_state[1] != 1u ||
+        window_state[2] != 0u || window_state[4] != static_cast<uint32_t>(BS)) {
+        return 3;
+    }
+
+    // 4. predBuf carries the 1.0f flag copies from the last check round
+    for (int slot = 0; slot < NUM_EXPANDED; slot++) {
+        if (pred_buf[slot * TILE_W] != 1.0f) return 4;
+    }
+
+    return 0;
+}

--- a/benchmark/one-level-arch/test/kernel/multi_thread/moe_dispatch/Makefile
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/moe_dispatch/Makefile
@@ -1,0 +1,3 @@
+TARGET = $(ELF_DIR)/moe_dispatch_mt.elf
+SRC_FILE += $(TEST_ROOT)/$(CASE_SRC_DIR)/$(TESTCASE).cpp
+include ../../../common/Makefile.common

--- a/benchmark/one-level-arch/test/kernel/multi_thread/moe_dispatch/compile.all
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/moe_dispatch/compile.all
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Multi-thread (4-PE SPMD) MoE Dispatch compile test.
+# Run the ELF with: gfrun -t 1 -s softcore.multiThreadNum=4 -f <elf>
+
+: "${COMPILER_DIR:?Set COMPILER_DIR to the in-repo Linx compiler bin directory}"
+
+make TESTCASE=moe_dispatch_mt COMPILER_DIR=$COMPILER_DIR

--- a/benchmark/one-level-arch/test/kernel/multi_thread/moe_dispatch/src/moe_dispatch_mt.cpp
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/moe_dispatch/src/moe_dispatch_mt.cpp
@@ -1,0 +1,111 @@
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+#include <cmath>
+#include <cstring>
+#include "benchmark.h"
+#include "moe_dispatch_mt/moe_dispatch_mt.hpp"
+
+using namespace supernpu::tile_isa;
+
+using dtype = __bf16;
+
+constexpr int kBS = 8;
+constexpr int kH = 128;
+constexpr int kK = 4;
+constexpr int kMoeExpertNum = 4;
+constexpr int kTileW = 128;
+constexpr int kWindowStride = 256;  // 512B / 2B = 256 bf16 per slot
+constexpr int kSlotCount = kBS * kK;
+
+static dtype x[kBS * kH] __attribute__((aligned(4096))) = {};
+static int32_t expertIds[kBS * kK] __attribute__((aligned(4096))) = {};
+static float expertScales[kBS * kK] __attribute__((aligned(4096))) = {};
+static dtype expandXOut[kSlotCount * kH] __attribute__((aligned(4096))) = {};
+static int32_t expandIdxOut[kSlotCount * 3] __attribute__((aligned(4096))) = {};
+static float expandScalesOut[kSlotCount] __attribute__((aligned(4096))) = {};
+static int32_t sendCountsOut[kMoeExpertNum] __attribute__((aligned(4096))) = {};
+static int64_t expertTokenNumsOut[kMoeExpertNum] __attribute__((aligned(4096))) = {};
+static dtype windowData[kSlotCount * kWindowStride] __attribute__((aligned(4096))) = {};
+static float windowFlag[kSlotCount * kTileW] __attribute__((aligned(4096))) = {};
+static float predBuf[kSlotCount * kTileW] __attribute__((aligned(4096))) = {};
+static int32_t windowTriple[kSlotCount * 3] __attribute__((aligned(4096))) = {};
+// 4 header words + TileW flag floats + slack: keeps the 512B cumsum-flag tile
+// (stored at windowState+4) inside the buffer.
+static uint32_t windowState[4 + kTileW + 8] __attribute__((aligned(4096))) = {};
+static dtype outBuf[kSlotCount * kH] __attribute__((aligned(4096))) = {};
+// Multi-thread scratch: per-PE histograms + expert-major starts
+static int32_t cntLocal[4 * kMoeExpertNum] __attribute__((aligned(4096))) = {};
+static int32_t expertStarts[kMoeExpertNum] __attribute__((aligned(4096))) = {};
+
+// Keeps the non-leader park loop side-effecting so -O2 cannot drop it.
+static volatile uint32_t sParkSink = 0;
+
+int main() {
+    const uint32_t tid = get_thread_idx();
+
+    // Input init runs redundantly on every PE (deterministic, identical
+    // writes — same convention as group_token_vec_mt's genTopkIndex), so no
+    // extra barrier is needed before the kernel reads x / expertIds.
+    for (int i = 0; i < kBS * kH; i++) {
+        float fval = static_cast<float>(i) * 0.1f;
+        uint32_t bits; std::memcpy(&bits, &fval, 4);
+        uint16_t raw = (uint16_t)(bits >> 16);
+        std::memcpy(&x[i], &raw, 2);
+    }
+    for (int i = 0; i < kBS * kK; i++) {
+        expertIds[i] = i % kMoeExpertNum;
+        expertScales[i] = 0.25f;
+    }
+
+    BENCHSTART;
+
+    moe_dispatch_mt<dtype, kBS, kH, kK, kMoeExpertNum, kTileW, kWindowStride>(
+        x, expertIds, expertScales,
+        expandXOut, expandIdxOut, expandScalesOut,
+        sendCountsOut, expertTokenNumsOut,
+        windowData, windowFlag, predBuf, windowTriple, windowState, outBuf,
+        cntLocal, expertStarts);
+
+    BENCHEND;
+
+    // Verification runs on PE0 only (all outputs are visible after the
+    // kernel's final barrier). Non-leader PEs park: a worker reaching _end
+    // first raises exit_group and would truncate PE0's verification mid-way
+    // (the leader's exit ends the parked workers instead).
+    if (tid != 0) {
+        for (;;) {
+            sParkSink = tid;
+        }
+    }
+
+    int slotCnt = kBS * kK;
+    int32_t counts[4] = {0};
+    for (int i = 0; i < slotCnt; i++) counts[expertIds[i]]++;
+    int32_t cum[4] = {0};
+    int32_t ac = 0;
+    for (int e = 0; e < 4; e++) { ac += counts[e]; cum[e] = ac; }
+    for (int e = 0; e < 4; e++) {
+        if (sendCountsOut[e] != cum[e]) return 1;
+        if (expertTokenNumsOut[e] != counts[e]) return 2;
+    }
+    int q = 0;
+    for (int e = 0; e < 4; e++) {
+        for (int i = 0; i < slotCnt; i++) {
+            if (expertIds[i] != e) continue;
+            int tokenId = i / kK;
+            int topkId = i % kK;
+            if (expandIdxOut[q * 3 + 0] != 0) return 3;
+            if (expandIdxOut[q * 3 + 1] != tokenId) return 4;
+            if (expandIdxOut[q * 3 + 2] != topkId) return 5;
+            for (int j = 0; j < kH; j++) {
+                uint16_t exp_raw, act_raw;
+                std::memcpy(&exp_raw, &x[tokenId * kH + j], 2);
+                std::memcpy(&act_raw, &expandXOut[q * kH + j], 2);
+                uint16_t diff = exp_raw ^ act_raw;
+                if (diff != 0 && diff != 1) return 6;
+            }
+            q++;
+        }
+    }
+    return (q == slotCnt) ? 0 : 7;
+}


### PR DESCRIPTION
## Summary

Port `moe_dispatch_v2` and `moe_combine_v2` to the 4-PE SPMD multi-thread model, following the conventions of `kernels/multi_thread` (`get_thread_idx()` data partitioning + per-PE phase barriers, as in `group_token_vec_mt`).

### moe_dispatch_mt (`kernels/moe_dispatch_mt/` + `test/kernel/multi_thread/moe_dispatch/`)
- **Phase 1 pack**: PE tid owns slots `[tid*8, tid*8+8)` — x rows, window rows, flags, triples all PE-disjoint
- **Phase 2 cumsum**: per-PE local histogram → cross-PE reduce; each PE writes its assigned expert range (inclusive cumsum `sendCountsOut` + exclusive `expertStarts` scratch)
- **Phase 3 copy-out**: each PE re-emits its own slots at the expert-major position the single-PE version produces (`dstPos = expertStarts[eid] + rank`), so output rows are PE-disjoint with bit-identical ordering
- 3 `mtBarrier` phases; windowState init/writeback PE0-only

### moe_combine_mt (`kernels/moe_combine_mt/` + `test/kernel/multi_thread/moe_combine/`)
- **Phase 1 pack**: PE tid owns expanded rows `[tid*8, tid*8+8)`
- **Phase 2 reduce**: PE tid owns tokens `[tid*2, tid*2+2)`; barrier covers cross-PE window-slot reads; fp32 accumulate (TCVT/TMULS/TADD); clears own tokens flags
- 2 `combineMtBarrier` phases; barrier symbols independently named so both headers can coexist

### Test design
Both tests use **PE0-only verification + non-leader park loop** (leader exit ends parked workers) — avoids a worker reaching `_end` first and truncating PE0 verification via exit_group. moe_combine_mt additionally gains real precision verification (RNE bf16 reference, flag-clear check, windowState, predBuf) which the single-thread v2 test lacked.

## Verification

- Build: `linx_blockisa_llvm_musl` clang 15.0.4 (`-mlxbc -O2`), both compile clean on current main base
- Sim (functional model): `gfrun -t 1 -s softcore.multiThreadNum=4` → **R2 = 0** for both kernels; tile-op census confirms all 4 PEs execute tile ops (combine: 268/PE incl. TCVT/TMULS/TADD; dispatch: T0 252 / T1-3 240)
- Fault injection: broken expectations return R2=4 (dispatch) / R2=1 (combine) — FAIL path verified
- gfsim (timing model) cannot run SMT4 barrier kernels — model-side limitation tracked in a separate SuperScalarModel issue (minimal pure-barrier repro, no tile ops involved)

## Files

```
kernels/moe_dispatch_mt/moe_dispatch_mt.hpp      (4-PE SPMD dispatch: pack/cumsum/copy-out + 3 barriers)
kernels/moe_combine_mt/moe_combine_mt.hpp        (4-PE SPMD combine: pack/reduce + 2 barriers)
test/kernel/multi_thread/moe_dispatch/{Makefile,compile.all,src/moe_dispatch_mt.cpp}
test/kernel/multi_thread/moe_combine/{Makefile,compile.all,src/moe_combine_mt.cpp}
```