### PR TITLE
fix(normalization): harden dynamic 4PE solution validation

### DIFF
--- a/benchmark/one-level-arch/kernels/solution/normalization/group_norm_grad/group_norm_grad_pto.hpp
+++ b/benchmark/one-level-arch/kernels/solution/normalization/group_norm_grad/group_norm_grad_pto.hpp
@@ -46,24 +46,8 @@ inline int64_t workspace_elems(int64_t N, int64_t C, int64_t G) {
     return 2 * N * C + 2 * N * G;
 }
 
-constexpr int kMaxPeCount = 64;
-static volatile uint32_t kPeBarrier[kMaxPeCount] = {};
-
 __attribute__((noinline)) inline uint32_t read_pe_id() {
     return get_thread_idx();
-}
-
-template <int peNum>
-__attribute__((noinline)) void pe_barrier(uint32_t phase) {
-    static_assert(peNum > 0 && peNum <= kMaxPeCount);
-    if constexpr (peNum > 1) {
-        const uint32_t pe = read_pe_id();
-        kPeBarrier[pe] = phase;
-        for (int participant = 0; participant < peNum; ++participant) {
-            while (kPeBarrier[participant] < phase) {
-            }
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -393,40 +377,31 @@ void group_norm_grad(dtype *dy, dtype *x, float *mean, float *rstd,
 
     const float s = 1.0f / static_cast<float>(D * HxW);
 
-    for (int64_t nc = tid; nc < N * C; nc += peNum) {
-        const int64_t n = nc / C;
-        const int64_t c = nc % C;
-        gn_grad::spatial_reduce_nc<dtype, gm_h, gm_f, tile_h, tile_f,
-                                   tile_v>(dy, x, ds, db, N, C, HxW,
-                                           tile_hw, n, c);
-    }
-    gn_grad::pe_barrier<peNum>(1);
-
-    for (int64_t ng = tid; ng < N * G; ng += peNum) {
-        const int64_t n = ng / G;
-        const int64_t g = ng % G;
-        gn_grad::fused_params_group<dtype, gm_h, gm_f, tile_h, tile_f,
-                                    tile_v>(gamma, mean, rstd, ds, db,
-                                            c2_buf, c3_buf, N, C, G, D, n, g,
-                                            s);
-    }
-    gn_grad::pe_barrier<peNum>(2);
-
-    for (int64_t nc = tid; nc < N * C; nc += peNum) {
-        const int64_t n = nc / C;
-        const int64_t c = nc % C;
-        gn_grad::dx_nc<dtype, gm_h, gm_f, tile_h, tile_f, tile_v>(
-            dy, x, gamma, rstd, c2_buf, c3_buf, dx, N, C, G, D, HxW,
-            tile_hw, n, c);
-    }
-
+    // Keep all dependent stages of a group on one PE. This avoids cross-PE
+    // workspace dependencies and does not require a software barrier.
     for (int64_t g = tid; g < G; g += peNum) {
+        const int64_t c0 = g * D;
+        for (int64_t n = 0; n < N; ++n) {
+            for (int64_t d = 0; d < D; ++d) {
+                gn_grad::spatial_reduce_nc<dtype, gm_h, gm_f, tile_h, tile_f,
+                                           tile_v>(dy, x, ds, db, N, C, HxW,
+                                                   tile_hw, n, c0 + d);
+            }
+            gn_grad::fused_params_group<dtype, gm_h, gm_f, tile_h, tile_f,
+                                        tile_v>(gamma, mean, rstd, ds, db,
+                                                c2_buf, c3_buf, N, C, G, D,
+                                                n, g, s);
+            for (int64_t d = 0; d < D; ++d) {
+                gn_grad::dx_nc<dtype, gm_h, gm_f, tile_h, tile_f, tile_v>(
+                    dy, x, gamma, rstd, c2_buf, c3_buf, dx, N, C, G, D, HxW,
+                    tile_hw, n, c0 + d);
+            }
+        }
         gn_grad::dbeta_group<dtype, gm_h, gm_f, tile_h, tile_f>(db, dbeta, N,
                                                                 C, D, g);
         gn_grad::dgamma_group<dtype, gm_h, gm_f, tile_h, tile_f, tile_v>(
             ds, db, mean, rstd, dgamma, N, C, G, D, g);
     }
-    gn_grad::pe_barrier<peNum>(3);
 }
 
 #endif // SUPERNPU_GROUP_NORM_GRAD_PTO_HPP

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/Makefile
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/Makefile
@@ -7,7 +7,6 @@ PE_NUM ?= 4
 ifneq ($(PE_NUM),4)
 $(error group_norm_grad supports only the dynamic 4PE testcase)
 endif
-START_FILE = $(ROOT)/test/common/_start_multipe.s
 ifeq ($(TESTCASE), group_norm_grad)
 DEFINES += -DDType=$(DType) -DN_BATCH=$(N_BATCH) -DC_CH=$(C_CH)
 DEFINES += -DG_GRP=$(G_GRP) -DHxW_SZ=$(HxW_SZ) -DPE_NUM=$(PE_NUM)

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/gen_group_norm_grad_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/gen_group_norm_grad_data.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_group_norm_grad_group_norm_grad"
     "_DType__half_N32_C16_G8_HxW8192_PE4"

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/group_norm_grad.cpp
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/group_norm_grad.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "benchmark.h"
 #include "fileop.h"
 #include "solution/normalization/group_norm_grad/group_norm_grad_pto.hpp"
 
@@ -60,15 +61,15 @@ int main() {
     constexpr int64_t kWs =
         2 * N_BATCH * C_CH + 2 * N_BATCH * G_GRP;
 
-    static dtype dy_buf[kElems];
-    static dtype x_buf[kElems];
-    static float mean_buf[N_BATCH * G_GRP];
-    static float rstd_buf[N_BATCH * G_GRP];
-    static dtype gamma_buf[C_CH];
-    static dtype dx_buf[kElems];
-    static dtype dgamma_buf[C_CH];
-    static dtype dbeta_buf[C_CH];
-    static float workspace_buf[kWs];
+    alignas(4096) static dtype dy_buf[kElems];
+    alignas(4096) static dtype x_buf[kElems];
+    alignas(4096) static float mean_buf[N_BATCH * G_GRP];
+    alignas(4096) static float rstd_buf[N_BATCH * G_GRP];
+    alignas(4096) static dtype gamma_buf[C_CH];
+    alignas(4096) static dtype dx_buf[kElems];
+    alignas(4096) static dtype dgamma_buf[C_CH];
+    alignas(4096) static dtype dbeta_buf[C_CH];
+    alignas(4096) static float workspace_buf[kWs];
 
     dtype *dy = dy_buf;
     dtype *x = x_buf;
@@ -103,8 +104,10 @@ int main() {
     }
 #endif
 
+    BENCHSTART;
     group_norm_grad<dtype, PE_NUM>(dy, x, mean, rstd, gamma, tiling_info, dx,
                                   dgamma, dbeta, workspace);
+    BENCHEND;
 
 #ifdef RES_CHECK
     kernel_done[tid] = 1;

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/group_norm_grad_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/group_norm_grad_data_compare.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_group_norm_grad_group_norm_grad"
     "_DType__half_N32_C16_G8_HxW8192_PE4"

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/Makefile
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/Makefile
@@ -6,7 +6,6 @@ PE_NUM ?= 4
 ifneq ($(PE_NUM),4)
 $(error group_norm_grad_1d supports only the dynamic 4PE testcase)
 endif
-START_FILE = $(ROOT)/test/common/_start_multipe.s
 ifeq ($(TESTCASE), group_norm_grad_1d)
 DEFINES += -DDType=$(DType) -DN_BATCH=$(N_BATCH) -DC_CH=$(C_CH)
 DEFINES += -DG_GRP=$(G_GRP) -DPE_NUM=$(PE_NUM)

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/src/gen_group_norm_grad_1d_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/src/gen_group_norm_grad_1d_data.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_group_norm_grad_1d_group_norm_grad_1d_DType__half_N512_C64_G8_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/src/group_norm_grad_1d.cpp
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/src/group_norm_grad_1d.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "benchmark.h"
 #include "fileop.h"
 #include "solution/normalization/group_norm_grad_1d/group_norm_grad_1d_pto.hpp"
 
@@ -57,14 +58,14 @@ int main() {
     const int64_t C = tiling_info[1];
     const int64_t G = tiling_info[2];
 
-    static dtype dy_buf[N_BATCH * C_CH];
-    static dtype x_buf[N_BATCH * C_CH];
-    static float mean_buf[N_BATCH * G_GRP];
-    static float rstd_buf[N_BATCH * G_GRP];
-    static dtype gamma_buf[C_CH];
-    static dtype dx_buf[N_BATCH * C_CH];
-    static dtype dgamma_buf[C_CH];
-    static dtype dbeta_buf[C_CH];
+    alignas(4096) static dtype dy_buf[N_BATCH * C_CH];
+    alignas(4096) static dtype x_buf[N_BATCH * C_CH];
+    alignas(4096) static float mean_buf[N_BATCH * G_GRP];
+    alignas(4096) static float rstd_buf[N_BATCH * G_GRP];
+    alignas(4096) static dtype gamma_buf[C_CH];
+    alignas(4096) static dtype dx_buf[N_BATCH * C_CH];
+    alignas(4096) static dtype dgamma_buf[C_CH];
+    alignas(4096) static dtype dbeta_buf[C_CH];
 
     dtype *dy = dy_buf;
     dtype *x = x_buf;
@@ -98,8 +99,10 @@ int main() {
     }
 #endif
 
+    BENCHSTART;
     group_norm_grad_1d<dtype, PE_NUM>(dy, x, mean, rstd, gamma, tiling_info,
                                       dx, dgamma, dbeta);
+    BENCHEND;
 
 #ifdef RES_CHECK
     kernel_done[tid] = 1;

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/src/group_norm_grad_1d_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad_1d/src/group_norm_grad_1d_data_compare.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_group_norm_grad_1d_group_norm_grad_1d_DType__half_N512_C64_G8_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm/Makefile
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm/Makefile
@@ -5,7 +5,6 @@ PE_NUM ?= 4
 ifneq ($(PE_NUM),4)
 $(error rms_norm supports only the dynamic 4PE testcase)
 endif
-START_FILE = $(ROOT)/test/common/_start_multipe.s
 ifeq ($(TESTCASE), rms_norm)
 DEFINES += -DDType=$(DType) -DPE_NUM=$(PE_NUM) -DG_A=$(G_A) -DG_R=$(G_R)
 TARGET = $(ELF_HEAD)_$(TESTCASE)_DType$(DType)_gA$(G_A)_gR$(G_R)_PE$(PE_NUM).elf

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/gen_rms_norm_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/gen_rms_norm_data.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_rms_norm_DType__half_gA512_gR8192_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/rms_norm.cpp
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/rms_norm.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "benchmark.h"
 #include "fileop.h"
 #include "solution/normalization/rms_norm/rms_norm_pto.hpp"
 
@@ -55,8 +56,8 @@ int main() {
     const int64_t g_a = tiling_info[0];
     const int64_t g_r = tiling_info[1];
 
-    static dtype input_buf[G_A * G_R];
-    static dtype output_buf[G_A * G_R];
+    alignas(4096) static dtype input_buf[G_A * G_R];
+    alignas(4096) static dtype output_buf[G_A * G_R];
     dtype *input = input_buf;
     dtype *output = output_buf;
 
@@ -75,7 +76,9 @@ int main() {
     }
 #endif
 
+    BENCHSTART;
     rms_norm<dtype, PE_NUM>(input, tiling_info, output, EPS);
+    BENCHEND;
 
 #ifdef RES_CHECK
     kernel_done[tid] = 1;

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/rms_norm_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/rms_norm_data_compare.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_rms_norm_DType__half_gA512_gR8192_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/Makefile
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/Makefile
@@ -5,7 +5,6 @@ PE_NUM ?= 4
 ifneq ($(PE_NUM),4)
 $(error rms_norm_binary supports only the dynamic 4PE testcase)
 endif
-START_FILE = $(ROOT)/test/common/_start_multipe.s
 ifeq ($(TESTCASE), rms_norm_binary)
 DEFINES += -DDType=$(DType) -DG_A=$(G_A) -DG_R=$(G_R) -DPE_NUM=$(PE_NUM)
 TARGET = $(ELF_HEAD)_$(TESTCASE)_DType$(DType)_gA$(G_A)_gR$(G_R)_PE$(PE_NUM).elf

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/gen_rms_norm_binary_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/gen_rms_norm_binary_data.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_binary_rms_norm_binary_DType__half_gA16_gR16384_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/rms_norm_binary.cpp
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/rms_norm_binary.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "benchmark.h"
 #include "fileop.h"
 #include "solution/normalization/rms_norm_binary/rms_norm_binary_pto.hpp"
 
@@ -67,9 +68,9 @@ int main() {
     const int64_t g_a = tiling_info[0];
     const int64_t g_r = tiling_info[1];
 
-    static dtype input_buf[G_A * G_R];
-    static dtype output_buf[G_A * G_R];
-    static float workspace_buf[K_MAX_LEVELS * G_A * K_WS_COLS];
+    alignas(4096) static dtype input_buf[G_A * G_R];
+    alignas(4096) static dtype output_buf[G_A * G_R];
+    alignas(4096) static float workspace_buf[K_MAX_LEVELS * G_A * K_WS_COLS];
     dtype *input = input_buf;
     dtype *output = output_buf;
     float *workspace = workspace_buf;
@@ -89,7 +90,9 @@ int main() {
     }
 #endif
 
+    BENCHSTART;
     rms_norm_binary<dtype, PE_NUM>(input, tiling_info, output, workspace, EPS);
+    BENCHEND;
 
 #ifdef RES_CHECK
     kernel_done[tid] = 1;

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/rms_norm_binary_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/rms_norm_binary_data_compare.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_binary_rms_norm_binary_DType__half_gA16_gR16384_PE4"
 )


### PR DESCRIPTION
## Summary

Follow-up correction for the normalization solution merged in #113.

- repartition GroupNormGrad by complete groups so dependent stages stay on one PE and no software spin barrier is required
- align all normalization test buffers to 4 KiB
- add benchmark markers for gfsim performance scope
- remove unused references to the nonexistent _start_multipe.s
- fix generator/comparator default compare paths

## Validation

4PE gfrun accuracy on SuperScalarModel bc7fae00988a3296a849b5e138b83db433d6c4c8:

- rms_norm [512, 8192]: PASS, max_abs=0.001953125
- rms_norm_binary [16, 16384]: PASS, max_abs=0.001953125
- group_norm_grad N=32,C=16,G=8,HxW=8192: PASS (dx/dgamma/dbeta)
- group_norm_grad_1d N=512,C=64,G=8,D=8: PASS (dx/dgamma/dbeta)

Forced-fourpe gfsim smoke:

- group_norm_grad N=1,C=16,G=8,HxW=256: PASS, reached SuperScalar Report Stop

Note: #113 is already merged, so it cannot be closed; this PR is its corrective follow-up.