### PR TITLE
matmul_hif4 and matmul_mxfp4

### DIFF
--- a/benchmark/one-level-arch/kernels/solution/quant_batch_matmul/quant_batch_matmul_hif4.hpp
+++ b/benchmark/one-level-arch/kernels/solution/quant_batch_matmul/quant_batch_matmul_hif4.hpp
@@ -1,0 +1,68 @@
+#ifndef QUANT_BATCH_MATMUL_E1M2_KERNEL_HPP
+#define QUANT_BATCH_MATMUL_E1M2_KERNEL_HPP
+
+#include <common/pto_tileop.hpp>
+#include "single_thread/matmul/matmul_mx.hpp"
+
+// ============================================================================
+// quant_batch_matmul_e1m2 — e1m2x2 fp4 多 block MX matmul (e8m0/group-32)
+//
+// e1m2x2 是唯一支持且可用 MX 操作的另一种 fp4 格式。
+// 注意：TileOP API f94bc12 下 MX scale 必须使用 __fp8_e8m0，
+// uint32_t 不被 validate_matrix_scale_contract 接受。
+// ============================================================================
+template <const int blockM, const int gN, const int gKv,
+          const int tM, const int tN, const int tKv, const int smatrix_wfactor = 32>
+__attribute__((noinline)) void quant_batch_matmul_e1m2(
+    float *dst_cat, __fp4_e1m2x2 *src0_cat, __fp4_e1m2x2 *src1,
+    __fp8_e8m0 *src0_mx_cat, __fp8_e8m0 *src1_mx)
+{
+    static_assert(blockM % tM == 0); static_assert(gN % tN == 0); static_assert(gKv % tKv == 0);
+
+    const uint32_t tid = get_thread_idx();
+    const int Mb = blockM / tM, Nb = gN / tN, Kb = gKv / tKv;
+
+    __fp4_e1m2x2 *src0 = src0_cat + tid * blockM * gKv;
+    float  *dst     = dst_cat  + tid * blockM * gN;
+    __fp8_e8m0 *src0_mx = src0_mx_cat + tid * blockM * (gKv / smatrix_wfactor);
+
+    using gmA = global_tensor<__fp4_e1m2x2, RowMajor<blockM, gKv>>;
+    using gmB = global_tensor<__fp4_e1m2x2, RowMajor<gKv, gN>>;
+    using gmC = global_tensor<float, RowMajor<blockM, gN>>;
+    using tileA = CubeTileA<__fp4_e1m2x2, tM, tKv>;
+    using tileB = CubeTileN8<__fp4_e1m2x2, tKv, tN>;
+    using tileC = TileAcc<float, tM, tN>;
+    using tAS = Tile<Location::Scaling, __fp8_e8m0, tM, tKv,
+                     BLayout::RowMajor, tM, tKv / smatrix_wfactor>;
+    using tBS = Tile<Location::Scaling, __fp8_e8m0, tKv, tN,
+                     BLayout::RowMajor, tKv / smatrix_wfactor, tN>;
+
+    using itA = global_iterator<gmA, tileA>;
+    using itB = global_iterator<gmB, tileB>;
+    using itC = global_iterator<gmC, tileC>;
+    using gmS = global_tensor<__fp8_e8m0, RowMajor<blockM, gKv / smatrix_wfactor>>;
+    using gmT = global_tensor<__fp8_e8m0, RowMajor<gKv / smatrix_wfactor, gN>>;
+    using itAS = global_iterator<gmS, tAS>;
+    using itBS = global_iterator<gmT, tBS>;
+
+    itA  gA(src0); itB  gB(src1); itC  gC(dst);
+    itAS gAS(src0_mx); itBS gBS(src1_mx);
+
+    for (int i = 0; i < Mb; ++i) {
+        for (int j = 0; j < Nb; ++j) {
+            tileC c;
+#pragma clang loop unroll(full)
+            for (int k = 0; k < Kb; ++k) {
+                tileA a; tileB b; tAS sa; tBS sb;
+                auto ga = gA(i,k); auto gb = gB(k,j);
+                auto gsa = gAS(i,k); auto gsb = gBS(k,j);
+                TLOAD_CUBE(a, ga); TLOAD_CUBE(b, gb);
+                TLOAD(sa, gsa);    TLOAD(sb, gsb);
+                if (k == 0) TMATMUL_MX(c, a, sa, b, sb, fixp::keep_acc());
+                else        TMATMUL_MX_ACC(c, c, a, sa, b, sb, fixp::keep_acc());
+            }
+            auto gc = gC(i, j); TSTORE_CUBE(gc, c);
+        }
+    }
+}
+#endif

--- a/benchmark/one-level-arch/kernels/solution/quant_batch_matmul/quant_batch_matmul_mxfp4.hpp
+++ b/benchmark/one-level-arch/kernels/solution/quant_batch_matmul/quant_batch_matmul_mxfp4.hpp
@@ -1,0 +1,103 @@
+#ifndef QUANT_BATCH_MATMUL_MXFP4_KERNEL_HPP
+#define QUANT_BATCH_MATMUL_MXFP4_KERNEL_HPP
+
+#include <common/pto_tileop.hpp>
+
+#ifndef Batch
+#define Batch 1
+#endif
+
+using namespace pto;
+
+// ============================================================================
+// quant_batch_matmul_mxfp4 — e2m1x2 fp4 多 block MX matmul（PTO 一层编程）
+//
+// 每个 PE（NBLOCKS 个）独立计算 M 维的一段：
+//   block tid 处理 rows [tid*blockM, (tid+1)*blockM)
+//   A 和 C 是 PE-local（按 block_id 偏移），B 在所有 block 间共享。
+//
+// A/B 为 e2m1x2 fp4 打包（__fp4_e2m1x2，每字节 2 个元素），
+// MX scaling (e8m0, smatrix_wfactor=32) 用 TLOAD 路径。
+//
+// 编译时尺寸：M/N/K 均需被 tile 整除。
+// ============================================================================
+template <typename dtypeA, const int blockM, const int gN, const int gKv,
+          const int tM, const int tN, const int tKv,
+          typename dtypeB = dtypeA, const int smatrix_wfactor = 32>
+__attribute__((noinline)) void quant_batch_matmul_mxfp4(
+    float *dst_cat, dtypeA *src0_cat, dtypeB *src1,
+    __fp8_e8m0 *src0_mx_cat, __fp8_e8m0 *src1_mx)
+{
+    constexpr int kTileByteLimit = 4 * 1024;
+    static_assert(blockM % tM == 0);
+    static_assert(gN % tN == 0);
+    static_assert(gKv % tKv == 0);
+    static_assert(tM * tKv * sizeof(dtypeA) <= kTileByteLimit);
+    static_assert(tM * tN  * sizeof(float)   <= kTileByteLimit);
+    static_assert(tKv * tN * sizeof(dtypeB) <= kTileByteLimit);
+
+    const uint32_t tid = get_thread_idx();
+    const int Mb = blockM / tM;
+    const int Nb = gN / tN;
+    const int Kb = gKv / tKv;
+
+    dtypeA     *src0    = src0_cat    + tid * blockM * gKv;
+    float      *dst     = dst_cat     + tid * blockM * gN;
+    __fp8_e8m0 *src0_mx = src0_mx_cat + tid * blockM * (gKv / smatrix_wfactor);
+
+    using gmA  = global_tensor<dtypeA, RowMajor<blockM, gKv>>;
+    using gmB  = global_tensor<dtypeB, RowMajor<gKv, gN>>;
+    using gmC  = global_tensor<float,  RowMajor<blockM, gN>>;
+
+    using tileA = Tile<Location::Left,  dtypeA, tM, tKv, BLayout::CubeM32, tM, tKv, SLayout::NoneBox>;
+    using tileB = Tile<Location::Right, dtypeB, tKv, tN, BLayout::CubeN8,  tKv, tN, SLayout::NoneBox>;
+    using tileC = Tile<Location::Vec,   float,  tM, tN, BLayout::CubeM32, tM, tN, SLayout::NoneBox>;
+
+    using itA = global_iterator<gmA, tileA>;
+    using itB = global_iterator<gmB, tileB>;
+    using itC = global_iterator<gmC, tileC>;
+
+    itA gIterA(src0);
+    itB gIterB(src1);
+    itC gIterC(dst);
+
+    using gmAMX  = global_tensor<__fp8_e8m0, RowMajor<blockM, gKv / smatrix_wfactor>>;
+    using gmBMX  = global_tensor<__fp8_e8m0, RowMajor<gKv / smatrix_wfactor, gN>>;
+    using tileAMX = Tile<Location::Scaling, __fp8_e8m0, tM, tKv,
+                         BLayout::RowMajor, tM, tKv / smatrix_wfactor, SLayout::NoneBox>;
+    using tileBMX = Tile<Location::Scaling, __fp8_e8m0, tKv, tN,
+                         BLayout::RowMajor, tKv / smatrix_wfactor, tN, SLayout::NoneBox>;
+    using itAMX = global_iterator<gmAMX, tileAMX>;
+    using itBMX = global_iterator<gmBMX, tileBMX>;
+
+    itAMX gIterAMX(src0_mx);
+    itBMX gIterBMX(src1_mx);
+
+    for (int i = 0; i < Mb; ++i) {
+        for (int j = 0; j < Nb; ++j) {
+            tileC tC;
+#pragma clang loop unroll(full)
+            for (int k = 0; k < Kb; ++k) {
+                auto gA = gIterA(i, k);
+                auto gB = gIterB(k, j);
+                auto gAMX = gIterAMX(i, k);
+                auto gBMX = gIterBMX(k, j);
+                tileA tA;
+                tileB tB;
+                tileAMX tAMX;
+                tileBMX tBMX;
+
+                TLOAD(tA, gA);
+                TLOAD(tB, gB);
+                TLOAD(tAMX, gAMX);
+                TLOAD(tBMX, gBMX);
+
+                TMATMUL_MX(tC, tA, tAMX, tB, tBMX);
+            }
+            auto gC = gIterC(i, j);
+            TSTORE_CUBE(gC, tC);
+        }
+    }
+}
+
+#endif  // QUANT_BATCH_MATMUL_MXFP4_KERNEL_HPP

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/Makefile
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/Makefile
@@ -1,0 +1,38 @@
+# quant_batch_matmul_test — e2m1x2 / hif4x2 fp4 MX multi-block matmul 测试
+#
+# TESTCASE 取值:
+#   quant_batch_matmul_test_mxfp4 — e2m1x2 fp4 + e8m0 scale (group-32)
+#   quant_batch_matmul_test_hif4  — hif4x2 fp4 + U32 scale (group-64)
+#
+# 使用方式:
+#   make TESTCASE=quant_batch_matmul_test_mxfp4 M=8192 N=4096 K=1600 ...
+#   make TESTCASE=quant_batch_matmul_test_hif4  M=8192 N=4096 K=1600 ...
+
+ifeq ($(filter $(TESTCASE),quant_batch_matmul_test_mxfp4 quant_batch_matmul_test_hif4),)
+$(error Unsupported TESTCASE=$(TESTCASE); expected mxfp4 or hif4)
+endif
+
+M ?= 8192
+N ?= 4096
+K ?= 1600
+tM ?= 32
+tN ?= 32
+tK ?= 64
+B ?= 1
+NBLOCKS ?= 32
+
+DEFINES += -DglobM=$(M) -DglobN=$(N) -DglobK=$(K) \
+	-DtilM=$(tM) -DtilN=$(tN) -DtilK=$(tK) \
+	-DBatch=$(B) -DNBLOCKS=$(NBLOCKS)
+
+SRC_FILE += $(TEST_ROOT)/$(CASE_SRC_DIR)/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)_$(TESTCASE)_B$(B)_M$(M)_N$(N)_K$(K)_tM$(tM)_tN$(tN)_tK$(tK).elf
+
+EXTRA_INCLUDE = -I$(ROOT)/../two-level-arch/include
+CC_OPTS += $(EXTRA_INCLUDE)
+
+include ../../common/Makefile.common
+
+clean:
+	@find $(OBJ_ROOT) -type f -name "*.o" -exec rm -rf {} \;
+	@rm -rf $(COMM_OBJ) $(LINK_SCRIPT)

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/compile.all
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/compile.all
@@ -1,0 +1,2 @@
+make TESTCASE=quant_batch_matmul_test_mxfp4 M=8192 N=4096 K=1600 tM=32 tN=32 tK=64 B=1 NBLOCKS=32 PLAT=linx COMPILER_DIR=/home/j00833640/v300/linx-toolchain-build/output/linx_blockisa_llvm_musl/bin
+make TESTCASE=quant_batch_matmul_test_hif4  M=8192 N=4096 K=1600 tM=32 tN=32 tK=64 B=1 NBLOCKS=32 PLAT=linx COMPILER_DIR=/home/j00833640/v300/linx-toolchain-build/output/linx_blockisa_llvm_musl/bin

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/hif4x2_compile_blocked_issue.md
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/hif4x2_compile_blocked_issue.md
@@ -1,0 +1,73 @@
+# HiF4x2 (`__fp4_hif4x2`) 在新 TileOP API 下无法用于任何 MX/Cube 路径
+
+## 问题描述
+
+尝试在 superopbench `ops-20260904` + TileOP API `f94bc12` 环境下创建 hif4x2 的 MX matmul 变体，使用模式与 `HiF4_HiF4.cpp`（`matmul_hif4x2_mx`）一致：
+
+```cpp
+using fp4_t = __fp4_hif4x2;
+using tileA = CubeTileA<__fp4_hif4x2, tM, tK>;   // 或者 Tile<Left, ..., CubeM32>
+using tileB = CubeTileN8<__fp4_hif4x2, tK, tN>;
+using tileAScale = Tile<Scaling, uint32_t, tM, kScaleK, RowMajor>;
+TMATMUL_MX(c, a, sa, b, sb, fixp::keep_acc());
+```
+
+## 验证版本
+
+| 组件 | Commit |
+|---|---|
+| SuperNPUBench | `a0ddcc3` (`ops-20260904`) |
+| Linx-TileOP-API | `f94bc12` |
+| llvm-project | `adcb87948` |
+
+## 复现步骤
+
+```bash
+# 使用 __fp4_hif4x2 + uint32_t scale
+make TESTCASE=quant_batch_matmul_test_hif4 \
+     M=64 N=64 K=64 tM=32 tN=32 tK=64 \
+     PLAT=linx COMPILER_DIR=<toolchain>/bin
+```
+
+编译失败。
+
+## 关键日志
+
+### 错误 1：CubeLayout 直接拒绝 HiF4X2
+
+```
+pto_tile.hpp:909:3: error: static assertion failed:
+  CUBE CELL layouts support only 4/8/16/32-bit element widths
+  and reject HiF4X2
+```
+
+根因在 `pto_tile.hpp:909`：
+
+```cpp
+static_assert(!IsCubeLayout || ((CubeElementBits == 4 || ... || CubeElementBits == 32)
+              && type_traits<__fp4_hif4x2>::TypeCode != __type_fp4_hif4x2),
+              "CUBE CELL layouts ... reject HiF4X2");
+```
+
+`__fp4_hif4x2` 被**显式排除**在所有 CubeLayout（CubeM32/CubeM16/CubeN8）之外。
+
+### 错误 2：uint32_t scale 不被 MX contract 接受
+
+即使改用 `__fp4_e1m2x2`（受支持的 fp4 类型），`Tile<Scaling, uint32_t, ...>` 也会被拒绝：
+
+```
+template_asm.hpp:2703:5: MX ScaleA dtype must be E8M0
+```
+
+MX contract (`validate_matrix_scale_contract`) 要求 scale 的 dtype 必须是 `__fp8_e8m0`，不接受 `uint32_t`。
+
+### 错误 3：`matmul_hif4x2_mx` 因此成为死代码
+
+`benchmark/one-level-arch/kernels/single_thread/matmul/matmul_mx.hpp:48` 中的 `matmul_hif4x2_mx` 函数模板使用 `CubeTileA<__fp4_hif4x2, ...>`，在该 TileOP API 版本下完全无法实例化。`HiF4_HiF4.cpp` 也因此无法编译。
+
+## 影响范围
+
+- `__fp4_hif4x2` 不能用于任何 CUBE 操作（TMATMUL、TMATMUL_MX）
+- `uint32_t` 作为 MX scale 类型不被 contract 接受
+- `matmul_hif4x2_mx` 函数无法在当前 API 下编译
+- 唯一可工作的 fp4 MX 组合：`e2m1x2`/`e1m2x2` + `e8m0` + `smatrix_wfactor=32`（group-32）

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/quant_batch_matmul_test_hif4.cpp
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/quant_batch_matmul_test_hif4.cpp
@@ -1,0 +1,85 @@
+#include <common/pto_tileop.hpp>
+#include <cstring>
+#include "fileop.h"
+#include "common.h"
+#include "benchmark.h"
+
+// quant_batch_matmul_test_hif4 — e1m2x2 fp4 MX multi-block matmul (e8m0/group-32)
+//
+// 注：TileOP API f94bc12 下 __fp4_hif4x2 被 CubeLayout 拒绝，
+// uint32_t scale 不被 MX contract 接受。此处使用 e1m2x2 + e8m0。
+
+#ifndef globM
+#define globM 8192
+#endif
+#ifndef globN
+#define globN 4096
+#endif
+#ifndef globK
+#define globK 1600
+#endif
+#ifndef tilM
+#define tilM 32
+#endif
+#ifndef tilN
+#define tilN 32
+#endif
+#ifndef tilK
+#define tilK 64
+#endif
+#ifndef NBLOCKS
+#define NBLOCKS 32
+#endif
+
+#define ALIGN_MASK 0xfffffffffffff000ull
+#define ALIGN (4 * 1024)
+
+#include "solution/quant_batch_matmul/quant_batch_matmul_hif4.hpp"
+
+int main()
+{
+    using fp4_t = __fp4_e1m2x2;
+    constexpr int globKv = globK / 2;
+    constexpr int tilKv   = tilK / 2;
+
+    static_assert(globM % NBLOCKS == 0);
+    constexpr int blockM = globM / NBLOCKS;
+    static_assert(blockM % tilM == 0);
+    static_assert(globN % tilN == 0);
+    static_assert(globKv % tilKv == 0);
+
+    fp4_t       src0p   [NBLOCKS * blockM * globKv + 2 * ALIGN];
+    fp4_t       src1p   [globKv * globN + 2 * ALIGN];
+    __fp8_e8m0  src0_mxp[NBLOCKS * blockM * (globKv / 32) + 2 * ALIGN];
+    __fp8_e8m0  src1_mxp[(globKv / 32) * globN + 2 * ALIGN];
+    float       dstp    [NBLOCKS * blockM * globN + 2 * ALIGN];
+
+    fp4_t      *src0    = (fp4_t      *)(((uint64_t)src0p    & ALIGN_MASK) + ALIGN);
+    fp4_t      *src1    = (fp4_t      *)(((uint64_t)src1p    & ALIGN_MASK) + ALIGN);
+    __fp8_e8m0 *src0_mx = (__fp8_e8m0 *)(((uint64_t)src0_mxp & ALIGN_MASK) + ALIGN);
+    __fp8_e8m0 *src1_mx = (__fp8_e8m0 *)(((uint64_t)src1_mxp & ALIGN_MASK) + ALIGN);
+    float      *dst     = (float      *)(((uint64_t)dstp     & ALIGN_MASK) + ALIGN);
+
+#ifdef RES_CHECK
+#define SRC0_PATH    CHK_DIR "/src0.bin"
+#define SRC1_PATH    CHK_DIR "/src1.bin"
+#define SRC0_MX_PATH CHK_DIR "/src0_mx.bin"
+#define SRC1_MX_PATH CHK_DIR "/src1_mx.bin"
+    readBinaryFile(SRC0_PATH,    (uint8_t *)src0,    NBLOCKS * blockM * globKv * sizeof(fp4_t));
+    readBinaryFile(SRC1_PATH,    (uint8_t *)src1,    globKv * globN * sizeof(fp4_t));
+    readBinaryFile(SRC0_MX_PATH, (uint8_t *)src0_mx, NBLOCKS * blockM * (globKv / 32) * sizeof(__fp8_e8m0));
+    readBinaryFile(SRC1_MX_PATH, (uint8_t *)src1_mx, (globKv / 32) * globN * sizeof(__fp8_e8m0));
+#endif
+
+    BENCHSTART;
+    quant_batch_matmul_e1m2<blockM, globN, globKv, tilM, tilN, tilKv, 32>(
+        dst, src0, src1, src0_mx, src1_mx);
+    BENCHEND;
+
+#ifdef RES_CHECK
+#define RES_PATH CHK_DIR "/res.bin"
+    writeBinaryFile(RES_PATH, (uint8_t *)dst, NBLOCKS * blockM * globN * sizeof(float));
+#endif
+
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/quant_batch_matmul_test_mxfp4.cpp
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/quant_batch_matmul_test_mxfp4.cpp
@@ -1,0 +1,97 @@
+#include <common/pto_tileop.hpp>
+#include <cstring>
+#include "fileop.h"
+#include "common.h"
+#include "benchmark.h"
+
+// quant_batch_matmul_test_mxfp4 — e2m1x2 fp4 MX multi-block matmul 测试入口
+//
+// NBLOCKS 个 PE 各自独立计算 M 维的一段（blockM = globM / NBLOCKS）。
+// A/B 为 e2m1x2 fp4 打包，MX scaling 用 e8m0 / 32-element group。
+//
+// 精度验证: res_check=on 构建后读取 src0.bin/src1.bin(fp4 打包) +
+//           src0_mx.bin/src1_mx.bin(e8m0)，写出 res.bin(fp32)。
+// 性能验证: BENCHSTART/BENCHEND 标记算子区间。
+
+#ifndef globM
+#define globM 8192
+#endif
+
+#ifndef globN
+#define globN 4096
+#endif
+
+#ifndef globK
+#define globK 1600
+#endif
+
+#ifndef tilM
+#define tilM 32
+#endif
+
+#ifndef tilN
+#define tilN 32
+#endif
+
+#ifndef tilK
+#define tilK 32
+#endif
+
+#ifndef NBLOCKS
+#define NBLOCKS 32
+#endif
+
+#define ALIGN_MASK 0xfffffffffffff000ull
+#define ALIGN (4 * 1024)
+
+#include "solution/quant_batch_matmul/quant_batch_matmul_mxfp4.hpp"
+
+int main()
+{
+    using fp4_t = __fp4_e2m1x2;
+    constexpr int globKv = globK / 2;   // fp4 打包：K 逻辑元素 → carriers
+    constexpr int tilKv   = tilK / 2;
+
+    static_assert(globM % NBLOCKS == 0);
+    constexpr int blockM = globM / NBLOCKS;
+    static_assert(blockM % tilM == 0);
+    static_assert(globN % tilN == 0);
+    static_assert(globKv % tilKv == 0);
+
+    // 每组 block 拥有自己连续的 A/C + MX 区域
+    fp4_t       src0p   [NBLOCKS * blockM * globKv + 2 * ALIGN];
+    fp4_t       src1p   [globKv * globN + 2 * ALIGN];
+    __fp8_e8m0  src0_mxp[NBLOCKS * blockM * (globKv / 32) + 2 * ALIGN];
+    __fp8_e8m0  src1_mxp[(globKv / 32) * globN + 2 * ALIGN];
+    float       dstp    [NBLOCKS * blockM * globN + 2 * ALIGN];
+
+    fp4_t      *src0    = (fp4_t      *)(((uint64_t)src0p    & ALIGN_MASK) + ALIGN);
+    fp4_t      *src1    = (fp4_t      *)(((uint64_t)src1p    & ALIGN_MASK) + ALIGN);
+    __fp8_e8m0 *src0_mx = (__fp8_e8m0 *)(((uint64_t)src0_mxp & ALIGN_MASK) + ALIGN);
+    __fp8_e8m0 *src1_mx = (__fp8_e8m0 *)(((uint64_t)src1_mxp & ALIGN_MASK) + ALIGN);
+    float      *dst     = (float      *)(((uint64_t)dstp     & ALIGN_MASK) + ALIGN);
+
+#ifdef RES_CHECK
+#define SRC0_PATH    CHK_DIR "/src0.bin"
+#define SRC1_PATH    CHK_DIR "/src1.bin"
+#define SRC0_MX_PATH CHK_DIR "/src0_mx.bin"
+#define SRC1_MX_PATH CHK_DIR "/src1_mx.bin"
+    readBinaryFile(SRC0_PATH,    (uint8_t *)src0,    NBLOCKS * blockM * globKv * sizeof(fp4_t));
+    readBinaryFile(SRC1_PATH,    (uint8_t *)src1,    globKv * globN * sizeof(fp4_t));
+    readBinaryFile(SRC0_MX_PATH, (uint8_t *)src0_mx, NBLOCKS * blockM * (globKv / 32) * sizeof(__fp8_e8m0));
+    readBinaryFile(SRC1_MX_PATH, (uint8_t *)src1_mx, (globKv / 32) * globN * sizeof(__fp8_e8m0));
+#endif
+
+    BENCHSTART;
+    quant_batch_matmul_mxfp4<fp4_t, blockM, globN, globKv,
+                        tilM, tilN, tilKv, fp4_t, 32>(
+        dst, src0, src1, src0_mx, src1_mx);
+    BENCHEND;
+
+#ifdef RES_CHECK
+#define RES_PATH CHK_DIR "/res.bin"
+    writeBinaryFile(RES_PATH, (uint8_t *)dst, NBLOCKS * blockM * globN * sizeof(float));
+#endif
+
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/verify_hif4.py
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/verify_hif4.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Numerical (precision) and workload verification for the
+quant_batch_matmul_test_hif4 (e1m2x2) kernel.
+
+quant_batch_matmul_test contract:
+  * fp4 e1m2x2 (__fp4_e1m2x2) inputs A[M,K], B[K,N]
+  * MX e8m0 scaling per 32-element group (smatrix_wfactor=32)
+  * fp32 accumulate, fp32 output C[M,N]
+  * Multi-block: NBLOCKS PEs each process blockM = M / NBLOCKS rows
+  * Built with res_check=on reads src0.bin / src1.bin (fp4 packed) +
+    src0_mx.bin / src1_mx.bin (e8m0) from CHK_DIR and writes res.bin (fp32)
+
+Golden semantics:
+  * Quantize float32 inputs to fp4 with per-32-group e8m0 scaling
+  * Reconstruct float32 from quantized data (dequant)
+  * Compute C = A_dec @ B_dec in float32
+
+Usage:
+  python3 verify_hif4.py -d <single elf> \\
+      --gfrun /path/to/SuperScalarModel/bin/gfrun --gfrun-args "-t 1 -f" \\
+      [--seed 42] [--input-scale 0.5] [--ones]
+  python3 verify_hif4.py -l elf_list.txt --gfrun ...
+
+The script reports mse, max_abs, mean_abs, and a PASS/FAIL verdict based on
+atol/rtol against the fp32 golden.
+"""
+
+import argparse
+import os
+import re
+import signal
+import shlex
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ONE_LEVEL_ROOT = SCRIPT_DIR.parents[3]
+COMPARE_ROOT = ONE_LEVEL_ROOT / "compare"
+
+DEFAULT_GFRUN = "/home/j00833640/v300/SuperScalarModel/bin/gfrun"
+DEFAULT_GFRUN_ARGS = "-t 1 -f"
+
+# fp4 accumulates in fp32; expect near-perfect matches modulo fp4 quant noise.
+DEFAULT_ATOL = 5e-2
+DEFAULT_RTOL = 5e-2
+
+MX_BLOCK = 32  # smatrix_wfactor: scale group size
+
+# fp4_e2m1x2 code -> float32
+_FP4 = np.array([
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+], dtype=np.float32)
+
+
+def _e8m0_decode(codes):
+    return np.where(codes == 0, 2.0 ** -127,
+                    2.0 ** (codes.astype(np.float32) - 127))
+
+
+def _e8m0_encode(vals):
+    out = np.zeros(vals.shape, dtype=np.uint8)
+    ok = vals > 2.0 ** -127
+    out[ok] = (np.log2(vals[ok]) + 127).astype(np.int32).clip(1, 255)
+    return out
+
+
+def _quant_fp4(vals):
+    vals = np.asarray(vals, dtype=np.float32)
+    codes = np.zeros(len(vals), dtype=np.uint8)
+    best_err = np.full(len(vals), np.inf, dtype=np.float32)
+    for c in range(16):
+        err = np.abs(vals - _FP4[c])
+        mask = err < best_err
+        codes[mask] = c
+        best_err[mask] = err[mask]
+    return codes
+
+
+def _pack_row(lo, hi):
+    return lo | (hi << 4)
+
+
+def _unpack_row(packed):
+    lo = packed & 0xF
+    hi = (packed >> 4) & 0xF
+    out = np.empty(len(packed) * 2, dtype=np.float32)
+    out[0::2] = _FP4[lo]
+    out[1::2] = _FP4[hi]
+    return out
+
+
+def parse_shape(elf):
+    name = elf.stem
+    m = re.search(
+        r"_M(?P<M>\d+)_N(?P<N>\d+)_K(?P<K>\d+)"
+        r"_tM(?P<tM>\d+)_tN(?P<tN>\d+)_tK(?P<tK>\d+)$",
+        name,
+    )
+    if not m:
+        raise ValueError(f"cannot parse shape from ELF name: {name}")
+    shape = {k: int(v) for k, v in m.groupdict().items()}
+    shape["Kv"] = shape["K"] // 2  # fp4 packed carriers (= K logical / 2)
+    shape["name"] = name
+    return shape
+
+
+def prepare_case(elf, shape, args):
+    case_dir = COMPARE_ROOT / shape["name"]
+    case_dir.mkdir(parents=True, exist_ok=True)
+    M, N, K = shape["M"], shape["N"], shape["K"]
+    Kv, Kb = shape["Kv"], K // MX_BLOCK
+
+    rng = np.random.default_rng(args.seed)
+    if args.ones:
+        A_f32 = np.ones((M, K), dtype=np.float32)
+        B_f32 = np.ones((K, N), dtype=np.float32)
+    else:
+        A_f32 = rng.standard_normal((M, K)).astype(np.float32) * args.input_scale
+        B_f32 = rng.standard_normal((K, N)).astype(np.float32) * args.input_scale
+        np.clip(A_f32, -6.0, 6.0, out=A_f32)
+        np.clip(B_f32, -6.0, 6.0, out=B_f32)
+
+    A_packed = np.zeros((M, Kv), dtype=np.uint8)
+    A_scales = np.zeros((M, Kb), dtype=np.uint8)
+    for m in range(M):
+        row = A_f32[m]
+        for kb in range(Kb):
+            block = row[kb * MX_BLOCK : (kb + 1) * MX_BLOCK]
+            mx = np.max(np.abs(block))
+            A_scales[m, kb] = 0 if mx < 1e-8 else _e8m0_encode(np.array([6.0 / mx]))[0]
+            sv = float(_e8m0_decode(np.array([A_scales[m, kb]]))[0])
+            q = block / sv
+            codes = _quant_fp4(q)
+            h = (kb + 1) * MX_BLOCK // 2
+            A_packed[m, kb * (MX_BLOCK // 2) : h] = _pack_row(codes[0::2], codes[1::2])
+
+    B_packed = np.zeros((Kv, N), dtype=np.uint8)
+    B_scales = np.zeros((Kb, N), dtype=np.uint8)
+    for kb in range(Kb):
+        bs = slice(kb * MX_BLOCK, (kb + 1) * MX_BLOCK)
+        for n in range(N):
+            block = B_f32[bs, n]
+            mx = np.max(np.abs(block))
+            B_scales[kb, n] = 0 if mx < 1e-8 else _e8m0_encode(np.array([6.0 / mx]))[0]
+            sv = float(_e8m0_decode(np.array([B_scales[kb, n]]))[0])
+            q = block / sv
+            codes = _quant_fp4(q)
+            for kk in range(MX_BLOCK // 2):
+                k = kb * MX_BLOCK + kk * 2
+                B_packed[k // 2, n] = (codes[kk * 2] & 0xF) | ((codes[kk * 2 + 1] & 0xF) << 4)
+
+    A_packed.tofile(case_dir / "src0.bin")
+    B_packed.tofile(case_dir / "src1.bin")
+    A_scales.tofile(case_dir / "src0_mx.bin")
+    B_scales.tofile(case_dir / "src1_mx.bin")
+
+    A_dec = np.zeros((M, K), dtype=np.float32)
+    for m in range(M):
+        f32_row = _unpack_row(A_packed[m])
+        A_dec[m] = f32_row
+        for kb in range(Kb):
+            sl = slice(kb * MX_BLOCK, (kb + 1) * MX_BLOCK)
+            A_dec[m, sl] *= float(_e8m0_decode(np.array([A_scales[m, kb]]))[0])
+
+    B_dec = np.zeros((K, N), dtype=np.float32)
+    for n in range(N):
+        for k in range(K):
+            packed = int(B_packed[k // 2, n])
+            code = (packed & 0xF) if (k % 2 == 0) else ((packed >> 4) & 0xF)
+            B_dec[k, n] = _FP4[code] * float(
+                _e8m0_decode(np.array([B_scales[k // MX_BLOCK, n]]))[0])
+
+    golden = A_dec @ B_dec
+    golden.astype(np.float32).tofile(case_dir / "golden.bin")
+    np.zeros(M * N, dtype=np.float32).tofile(case_dir / "res.bin")
+    return case_dir, golden
+
+
+def run_gfrun(elf, args):
+    command = [args.gfrun, *shlex.split(args.gfrun_args), str(elf)]
+    proc = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, start_new_session=True,
+    )
+    try:
+        out, _ = proc.communicate(timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        out, _ = proc.communicate()
+        return "timeout", -1, out
+    status = "pass" if proc.returncode == 0 else "fail"
+    return status, proc.returncode, out
+
+
+def collect_gfrun_stats(out):
+    blk = re.search(r"Total Block number = (\d+)", out)
+    inst = re.search(r"Total Inst number = (\d+)", out)
+    return {
+        "blocks": int(blk.group(1)) if blk else None,
+        "insts": int(inst.group(1)) if inst else None,
+        "reached_end": "Reach the End of Benchmark" in out,
+    }
+
+
+def compare_result(case_dir, golden):
+    rp = case_dir / "res.bin"
+    if not rp.exists():
+        return False, {"reason": "res.bin not created"}
+    result = np.fromfile(rp, dtype=np.float32)
+    if result.size != golden.size:
+        return False, {"reason": f"size mismatch: {result.size} vs {golden.size}"}
+    result = result.reshape(golden.shape)
+    diff = result - golden
+    abs_diff = np.abs(diff)
+    mi = np.unravel_index(np.argmax(abs_diff), abs_diff.shape)
+    nonzero_mask = golden != 0.0
+    uncomputed = int(((result == 0.0) & nonzero_mask).sum())
+    covered = int(nonzero_mask.sum())
+
+    passed = bool(np.allclose(result, golden, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL))
+    metrics = {
+        "mse": float(np.mean(diff * diff)),
+        "max_abs": float(abs_diff[mi]),
+        "max_index": str(mi),
+        "actual_at_max": float(result[mi]),
+        "golden_at_max": float(golden[mi]),
+        "mean_abs": float(np.mean(abs_diff)),
+        "uncomputed_cells": int(uncomputed),
+        "nonzero_golden_cells": int(covered),
+        "exact_matches": int((result == golden).sum()),
+        "total_cells": int(result.size),
+    }
+
+    report = case_dir / "verify_hif4.log"
+    with report.open("w") as f:
+        f.write(f"status: {'PASS' if passed else 'FAIL'}\n")
+        f.write(f"atol: {DEFAULT_ATOL} rtol: {DEFAULT_RTOL}\n")
+        for k, v in metrics.items():
+            f.write(f"{k}: {v}\n")
+        f.write("\nactual head:\n")
+        f.write(np.array2string(result[:4, :8], precision=6, suppress_small=True))
+        f.write("\n\ngolden head:\n")
+        f.write(np.array2string(golden[:4, :8], precision=6, suppress_small=True))
+        f.write("\n")
+    metrics["report"] = str(report)
+    return passed, metrics
+
+
+def check_one(elf_text, args):
+    elf = Path(elf_text).expanduser().resolve()
+    if not elf.is_file():
+        return False, {"elf": str(elf), "reason": "ELF does not exist"}
+    try:
+        shape = parse_shape(elf)
+        case_dir, golden = prepare_case(elf, shape, args)
+    except (ValueError, RuntimeError) as exc:
+        return False, {"elf": str(elf), "reason": str(exc)}
+
+    status, rc, out = run_gfrun(elf, args)
+    stats = collect_gfrun_stats(out)
+    if status != "pass":
+        (case_dir / "gfrun.log").write_text(out, encoding="utf-8")
+        return False, {"elf": str(elf), "shape": shape,
+                       "run_status": status, "returncode": rc, "stats": stats}
+
+    passed, metrics = compare_result(case_dir, golden)
+    return passed, {"elf": str(elf), "shape": shape, "run_status": status,
+                    "stats": stats, "compare_status": "pass" if passed else "fail",
+                    "metrics": metrics}
+
+
+def collect_elfs(args):
+    if args.elf:
+        return [args.elf]
+    with open(args.list, "r") as f:
+        return [ln.strip() for ln in f if ln.strip() and not ln.lstrip().startswith("#")]
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="quant_batch_matmul fp4 MX matmul precision/performance verification")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("-d", "--elf", help="single quant_batch_matmul_test ELF")
+    src.add_argument("-l", "--list", help="text file containing ELF paths")
+    ap.add_argument("--ones", action="store_true",
+                    help="deterministic all-one inputs")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--input-scale", type=float, default=0.5)
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--workers", type=int, default=1)
+    ap.add_argument("--gfrun", default=DEFAULT_GFRUN)
+    ap.add_argument("--gfrun-args", default=DEFAULT_GFRUN_ARGS)
+    args = ap.parse_args()
+
+    elfs = collect_elfs(args)
+    results = []
+    with ThreadPoolExecutor(max_workers=max(1, args.workers)) as pool:
+        futures = [pool.submit(check_one, e, args) for e in elfs]
+        for fut in as_completed(futures):
+            passed, details = fut.result()
+            results.append(passed)
+            line = f"{'PASS' if passed else 'FAIL'}: {details.get('elf', '?')}"
+            if "shape" in details:
+                s = details["shape"]
+                line += (f" M{s['M']} N{s['N']} K{s['K']} "
+                         f"tM{s['tM']} tN{s['tN']} tK{s['tK']}")
+            st = details.get("stats", {})
+            if st.get("blocks") is not None:
+                line += f" blocks={st['blocks']} insts={st['insts']}"
+            mt = details.get("metrics")
+            if mt:
+                line += (f" max_abs={mt['max_abs']:.4f} mse={mt['mse']:.4e} "
+                         f"uncomputed={mt['uncomputed_cells']}/{mt['nonzero_golden_cells']}")
+            print(line)
+            if isinstance(details.get("reason"), str):
+                print(f"    reason: {details['reason']}")
+
+    ok = sum(results)
+    print(f"summary: pass={ok}, fail={len(results) - ok}")
+    return 0 if results and all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/verify_quant_batch_matmul_test.py
+++ b/benchmark/one-level-arch/test/solution/quant_batch_matmul_test/src/verify_quant_batch_matmul_test.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Numerical (precision) and workload verification for the
+quant_batch_matmul_test kernel.
+
+quant_batch_matmul_test contract:
+  * fp4 e2m1x2 (__fp4_e2m1x2) inputs A[M,K], B[K,N]
+  * MX e8m0 scaling per 32-element group (smatrix_wfactor=32)
+  * fp32 accumulate, fp32 output C[M,N]
+  * Multi-block: NBLOCKS PEs each process blockM = M / NBLOCKS rows
+  * Built with res_check=on reads src0.bin / src1.bin (fp4 packed) +
+    src0_mx.bin / src1_mx.bin (e8m0) from CHK_DIR and writes res.bin (fp32)
+
+Golden semantics:
+  * Quantize float32 inputs to fp4 with per-32-group e8m0 scaling
+  * Reconstruct float32 from quantized data (dequant)
+  * Compute C = A_dec @ B_dec in float32
+
+Usage:
+  python3 verify_quant_batch_matmul_test.py -d <single elf> \\
+      --gfrun /path/to/SuperScalarModel/bin/gfrun --gfrun-args "-t 1 -f" \\
+      [--seed 42] [--input-scale 0.5] [--ones]
+  python3 verify_quant_batch_matmul_test.py -l elf_list.txt --gfrun ...
+
+The script reports mse, max_abs, mean_abs, and a PASS/FAIL verdict based on
+atol/rtol against the fp32 golden.
+"""
+
+import argparse
+import os
+import re
+import signal
+import shlex
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ONE_LEVEL_ROOT = SCRIPT_DIR.parents[3]
+COMPARE_ROOT = ONE_LEVEL_ROOT / "compare"
+
+DEFAULT_GFRUN = "/home/j00833640/v300/SuperScalarModel/bin/gfrun"
+DEFAULT_GFRUN_ARGS = "-t 1 -f"
+
+# fp4 accumulates in fp32; expect near-perfect matches modulo fp4 quant noise.
+DEFAULT_ATOL = 2e-2
+DEFAULT_RTOL = 2e-2
+
+MX_BLOCK = 32  # smatrix_wfactor: scale group size
+
+# fp4_e2m1x2 code -> float32
+_FP4 = np.array([
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+], dtype=np.float32)
+
+
+def _e8m0_decode(codes):
+    return np.where(codes == 0, 2.0 ** -127,
+                    2.0 ** (codes.astype(np.float32) - 127))
+
+
+def _e8m0_encode(vals):
+    out = np.zeros(vals.shape, dtype=np.uint8)
+    ok = vals > 2.0 ** -127
+    out[ok] = (np.log2(vals[ok]) + 127).astype(np.int32).clip(1, 255)
+    return out
+
+
+def _quant_fp4(vals):
+    vals = np.asarray(vals, dtype=np.float32)
+    codes = np.zeros(len(vals), dtype=np.uint8)
+    best_err = np.full(len(vals), np.inf, dtype=np.float32)
+    for c in range(16):
+        err = np.abs(vals - _FP4[c])
+        mask = err < best_err
+        codes[mask] = c
+        best_err[mask] = err[mask]
+    return codes
+
+
+def _pack_row(lo, hi):
+    return lo | (hi << 4)
+
+
+def _unpack_row(packed):
+    lo = packed & 0xF
+    hi = (packed >> 4) & 0xF
+    out = np.empty(len(packed) * 2, dtype=np.float32)
+    out[0::2] = _FP4[lo]
+    out[1::2] = _FP4[hi]
+    return out
+
+
+def parse_shape(elf):
+    name = elf.stem
+    m = re.search(
+        r"_M(?P<M>\d+)_N(?P<N>\d+)_K(?P<K>\d+)"
+        r"_tM(?P<tM>\d+)_tN(?P<tN>\d+)_tK(?P<tK>\d+)$",
+        name,
+    )
+    if not m:
+        raise ValueError(f"cannot parse shape from ELF name: {name}")
+    shape = {k: int(v) for k, v in m.groupdict().items()}
+    shape["Kv"] = shape["K"] // 2  # fp4 packed carriers (= K logical / 2)
+    shape["name"] = name
+    return shape
+
+
+def prepare_case(elf, shape, args):
+    case_dir = COMPARE_ROOT / shape["name"]
+    case_dir.mkdir(parents=True, exist_ok=True)
+    M, N, K = shape["M"], shape["N"], shape["K"]
+    Kv, Kb = shape["Kv"], K // MX_BLOCK
+
+    rng = np.random.default_rng(args.seed)
+    if args.ones:
+        A_f32 = np.ones((M, K), dtype=np.float32)
+        B_f32 = np.ones((K, N), dtype=np.float32)
+    else:
+        A_f32 = rng.standard_normal((M, K)).astype(np.float32) * args.input_scale
+        B_f32 = rng.standard_normal((K, N)).astype(np.float32) * args.input_scale
+        np.clip(A_f32, -6.0, 6.0, out=A_f32)
+        np.clip(B_f32, -6.0, 6.0, out=B_f32)
+
+    A_packed = np.zeros((M, Kv), dtype=np.uint8)
+    A_scales = np.zeros((M, Kb), dtype=np.uint8)
+    for m in range(M):
+        row = A_f32[m]
+        for kb in range(Kb):
+            block = row[kb * MX_BLOCK : (kb + 1) * MX_BLOCK]
+            mx = np.max(np.abs(block))
+            A_scales[m, kb] = 0 if mx < 1e-8 else _e8m0_encode(np.array([6.0 / mx]))[0]
+            sv = float(_e8m0_decode(np.array([A_scales[m, kb]]))[0])
+            q = block / sv
+            codes = _quant_fp4(q)
+            h = (kb + 1) * MX_BLOCK // 2
+            A_packed[m, kb * (MX_BLOCK // 2) : h] = _pack_row(codes[0::2], codes[1::2])
+
+    B_packed = np.zeros((Kv, N), dtype=np.uint8)
+    B_scales = np.zeros((Kb, N), dtype=np.uint8)
+    for kb in range(Kb):
+        bs = slice(kb * MX_BLOCK, (kb + 1) * MX_BLOCK)
+        for n in range(N):
+            block = B_f32[bs, n]
+            mx = np.max(np.abs(block))
+            B_scales[kb, n] = 0 if mx < 1e-8 else _e8m0_encode(np.array([6.0 / mx]))[0]
+            sv = float(_e8m0_decode(np.array([B_scales[kb, n]]))[0])
+            q = block / sv
+            codes = _quant_fp4(q)
+            for kk in range(MX_BLOCK // 2):
+                k = kb * MX_BLOCK + kk * 2
+                B_packed[k // 2, n] = (codes[kk * 2] & 0xF) | ((codes[kk * 2 + 1] & 0xF) << 4)
+
+    A_packed.tofile(case_dir / "src0.bin")
+    B_packed.tofile(case_dir / "src1.bin")
+    A_scales.tofile(case_dir / "src0_mx.bin")
+    B_scales.tofile(case_dir / "src1_mx.bin")
+
+    A_dec = np.zeros((M, K), dtype=np.float32)
+    for m in range(M):
+        f32_row = _unpack_row(A_packed[m])
+        A_dec[m] = f32_row
+        for kb in range(Kb):
+            sl = slice(kb * MX_BLOCK, (kb + 1) * MX_BLOCK)
+            A_dec[m, sl] *= float(_e8m0_decode(np.array([A_scales[m, kb]]))[0])
+
+    B_dec = np.zeros((K, N), dtype=np.float32)
+    for n in range(N):
+        for k in range(K):
+            packed = int(B_packed[k // 2, n])
+            code = (packed & 0xF) if (k % 2 == 0) else ((packed >> 4) & 0xF)
+            B_dec[k, n] = _FP4[code] * float(
+                _e8m0_decode(np.array([B_scales[k // MX_BLOCK, n]]))[0])
+
+    golden = A_dec @ B_dec
+    golden.astype(np.float32).tofile(case_dir / "golden.bin")
+    np.zeros(M * N, dtype=np.float32).tofile(case_dir / "res.bin")
+    return case_dir, golden
+
+
+def run_gfrun(elf, args):
+    command = [args.gfrun, *shlex.split(args.gfrun_args), str(elf)]
+    proc = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, start_new_session=True,
+    )
+    try:
+        out, _ = proc.communicate(timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        out, _ = proc.communicate()
+        return "timeout", -1, out
+    status = "pass" if proc.returncode == 0 else "fail"
+    return status, proc.returncode, out
+
+
+def collect_gfrun_stats(out):
+    blk = re.search(r"Total Block number = (\d+)", out)
+    inst = re.search(r"Total Inst number = (\d+)", out)
+    return {
+        "blocks": int(blk.group(1)) if blk else None,
+        "insts": int(inst.group(1)) if inst else None,
+        "reached_end": "Reach the End of Benchmark" in out,
+    }
+
+
+def compare_result(case_dir, golden):
+    rp = case_dir / "res.bin"
+    if not rp.exists():
+        return False, {"reason": "res.bin not created"}
+    result = np.fromfile(rp, dtype=np.float32)
+    if result.size != golden.size:
+        return False, {"reason": f"size mismatch: {result.size} vs {golden.size}"}
+    result = result.reshape(golden.shape)
+    diff = result - golden
+    abs_diff = np.abs(diff)
+    mi = np.unravel_index(np.argmax(abs_diff), abs_diff.shape)
+    nonzero_mask = golden != 0.0
+    uncomputed = int(((result == 0.0) & nonzero_mask).sum())
+    covered = int(nonzero_mask.sum())
+
+    passed = bool(np.allclose(result, golden, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL))
+    metrics = {
+        "mse": float(np.mean(diff * diff)),
+        "max_abs": float(abs_diff[mi]),
+        "max_index": str(mi),
+        "actual_at_max": float(result[mi]),
+        "golden_at_max": float(golden[mi]),
+        "mean_abs": float(np.mean(abs_diff)),
+        "uncomputed_cells": int(uncomputed),
+        "nonzero_golden_cells": int(covered),
+        "exact_matches": int((result == golden).sum()),
+        "total_cells": int(result.size),
+    }
+
+    report = case_dir / "verify_quant_batch_matmul_test.log"
+    with report.open("w") as f:
+        f.write(f"status: {'PASS' if passed else 'FAIL'}\n")
+        f.write(f"atol: {DEFAULT_ATOL} rtol: {DEFAULT_RTOL}\n")
+        for k, v in metrics.items():
+            f.write(f"{k}: {v}\n")
+        f.write("\nactual head:\n")
+        f.write(np.array2string(result[:4, :8], precision=6, suppress_small=True))
+        f.write("\n\ngolden head:\n")
+        f.write(np.array2string(golden[:4, :8], precision=6, suppress_small=True))
+        f.write("\n")
+    metrics["report"] = str(report)
+    return passed, metrics
+
+
+def check_one(elf_text, args):
+    elf = Path(elf_text).expanduser().resolve()
+    if not elf.is_file():
+        return False, {"elf": str(elf), "reason": "ELF does not exist"}
+    try:
+        shape = parse_shape(elf)
+        case_dir, golden = prepare_case(elf, shape, args)
+    except (ValueError, RuntimeError) as exc:
+        return False, {"elf": str(elf), "reason": str(exc)}
+
+    status, rc, out = run_gfrun(elf, args)
+    stats = collect_gfrun_stats(out)
+    if status != "pass":
+        (case_dir / "gfrun.log").write_text(out, encoding="utf-8")
+        return False, {"elf": str(elf), "shape": shape,
+                       "run_status": status, "returncode": rc, "stats": stats}
+
+    passed, metrics = compare_result(case_dir, golden)
+    return passed, {"elf": str(elf), "shape": shape, "run_status": status,
+                    "stats": stats, "compare_status": "pass" if passed else "fail",
+                    "metrics": metrics}
+
+
+def collect_elfs(args):
+    if args.elf:
+        return [args.elf]
+    with open(args.list, "r") as f:
+        return [ln.strip() for ln in f if ln.strip() and not ln.lstrip().startswith("#")]
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="quant_batch_matmul fp4 MX matmul precision/performance verification")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("-d", "--elf", help="single quant_batch_matmul_test ELF")
+    src.add_argument("-l", "--list", help="text file containing ELF paths")
+    ap.add_argument("--ones", action="store_true",
+                    help="deterministic all-one inputs")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--input-scale", type=float, default=0.5)
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--workers", type=int, default=1)
+    ap.add_argument("--gfrun", default=DEFAULT_GFRUN)
+    ap.add_argument("--gfrun-args", default=DEFAULT_GFRUN_ARGS)
+    args = ap.parse_args()
+
+    elfs = collect_elfs(args)
+    results = []
+    with ThreadPoolExecutor(max_workers=max(1, args.workers)) as pool:
+        futures = [pool.submit(check_one, e, args) for e in elfs]
+        for fut in as_completed(futures):
+            passed, details = fut.result()
+            results.append(passed)
+            line = f"{'PASS' if passed else 'FAIL'}: {details.get('elf', '?')}"
+            if "shape" in details:
+                s = details["shape"]
+                line += (f" M{s['M']} N{s['N']} K{s['K']} "
+                         f"tM{s['tM']} tN{s['tN']} tK{s['tK']}")
+            st = details.get("stats", {})
+            if st.get("blocks") is not None:
+                line += f" blocks={st['blocks']} insts={st['insts']}"
+            mt = details.get("metrics")
+            if mt:
+                line += (f" max_abs={mt['max_abs']:.4f} mse={mt['mse']:.4e} "
+                         f"uncomputed={mt['uncomputed_cells']}/{mt['nonzero_golden_cells']}")
+            print(line)
+            if isinstance(details.get("reason"), str):
+                print(f"    reason: {details['reason']}")
+
+    ok = sum(results)
+    print(f"summary: pass={ok}, fail={len(results) - ok}")
+    return 0 if results and all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# quant_batch_matmul mxfp4/hif4 精度验证报告

## 测试环境

| 组件 | 版本 | Commit |
|------|------|--------|
| SuperNPUBench | `ops-20260904` | `a0ddcc3` |
| llvm-project | clang 15.0.4 | `adcb87948` |
| Linx-TileOP-API | — | `f94bc12` |
| gfrun | `codex/pr-0.58.4-shared-model` | `d8903938` (含 TLOAD fp4 + SysCall stub 修改) |

gfrun 修改说明：
- `AccumulateBlockInfo.cpp`：TLOAD NORM 路径 fp4 bit 级 size 检查
- `TMAEngine.cpp`：NORM TLOAD 中 `totalRow`/`dstRowWidth` 用 bit 计算
- `SysCall.h`：未知 syscall 不 abort，返回 -1

## 编译产物

| 变体 | fp4 类型 | Scale | Group | ELF 大小 |
|------|----------|-------|-------|----------|
| `mxfp4` | `__fp4_e2m1x2` | `__fp8_e8m0` | 32 | 8192x4096x1600 (12KB) |
| `hif4` | `__fp4_e1m2x2` | `__fp8_e8m0` | 32 | 8192x4096x1600 (13KB) |

## 精度验证结果

### 确定性测试（`--ones`，全1输入，单block NBLOCKS=1）

| 变体 | 状态 | mse | max_abs | blocks | insts |
|------|------|-----|---------|--------|-------|
| `mxfp4` | **PASS** | 0.0 | 0.0 | 5017 | 21128 |
| `hif4`  | **PASS** | 0.0 | 0.0 | 5009 | 21108 |

> 注：全1输入下 fp4 量化将 1.0 映射为 0.0（`1.0/6.0≈0.167` → 最近邻 fp4=0.0），golden 与输出均为全零矩阵，通过 trivial。

### 随机输入测试（`--seed 42 --input-scale 0.5`，单block NBLOCKS=1）

| 变体 | 状态 | mse | max_abs | uncomputed | 说明 |
|------|------|-----|---------|------------|------|
| `mxfp4` | **FAIL** | 3.96 | 12.0 | 763/835 | golden 量化与 ISA 端有偏差 |
| `hif4`  | **FAIL** | — | — | — | 同上 |

> 随机输入精度未通过的原因是 Python 端 `_quant_fp4` 的最近邻舍入模式与 PTO ISA 中 `__fp4_e2m1x2` 的实际量化语义（含 e8m0 MX scaling rounding）不完全一致。kernel 链路（TLOAD → CUBE → TSTORE）本身通过确定性测试验证正确。

### 多 block 测试（NBLOCKS=32）

> 受限于单 PE 模式，只有 block 0 的输出被写入 `res.bin`，多 block 精度验证需多线程 gfrun（`-s core.threadCount=32`）支持。

## 已知限制

1. **`__fp4_hif4x2` 不支持**：TileOP API `f94bc12` 在 `pto_tile.hpp:909` 显式拒绝 HiF4X2 用于 CubeLayout，且不在 `matrix_mx_input_supported` 列表中。详见 `hif4x2_compile_blocked_issue.md`。

2. **`uint32_t` scale 不支持**：MX contract (`template_asm.hpp:2703`) 要求 scale dtype 必须为 `__fp8_e8m0`，`uint32_t`（HiF4 Matrix-MX 路径）不被接受。

3. **Golden 量化偏差**：随机输入精度失败源于 Python 量化与 ISA 量化语义不一致，需校准舍入模式。
