### PR TITLE
tileop-test: 新增 PTO-ISA microbench API 精度看护套件

### DIFF
--- a/benchmark/one-level-arch/test/solution/tileop-test/.gitignore
+++ b/benchmark/one-level-arch/test/solution/tileop-test/.gitignore
@@ -1,0 +1,2 @@
+# res_check runtime artifacts: host-generated inputs + dumped outputs per case.
+compare/

--- a/benchmark/one-level-arch/test/solution/tileop-test/Makefile.common
+++ b/benchmark/one-level-arch/test/solution/tileop-test/Makefile.common
@@ -1,0 +1,93 @@
+# tileop-test common Makefile
+# Self-contained variant that lives under
+# benchmark/one-level-arch/test/solution/tileop-test/<sub> and adds the
+# tileop-test common include path. Does not touch sibling families.
+
+ROOT := $(shell echo $(CURDIR) | sed -E 's@(.*)/benchmark/one-level-arch/test/.*@\1@')
+TEST_ROOT := $(ROOT)/benchmark/one-level-arch/test
+GUARD_ROOT := $(TEST_ROOT)/solution/tileop-test
+# category = the sub dir under tileop-test (vec/sfu/tlsu/cube/fixp/misc)
+CATEGORY := $(shell echo $(CURDIR) | sed -E 's@.*/solution/tileop-test/([^/]+).*@\1@')
+CATEGORY_NAME := $(shell echo $(CATEGORY) | sed -e 's/\//_/g')
+OBJ_ROOT := $(shell realpath $(ROOT)/output 2>/dev/null || echo $(ROOT)/output)
+CASE_SRC_DIR := benchmark/one-level-arch/test/solution/tileop-test/$(CATEGORY)/src
+ELF_DIR := $(OBJ_ROOT)/tileop-test/$(CATEGORY)/elf
+SRC_DIR := $(shell dirname $(SRC_FILE))
+OBJ_DIR := $(OBJ_ROOT)/$(CASE_SRC_DIR)
+ELF_HEAD := $(ELF_DIR)/$(CATEGORY_NAME)
+
+# Platform settings
+PLAT ?= linx
+baremetal ?= off
+
+ifeq ($(PLAT), cpu)
+DEFINES += -D__cpu_sim__
+COMPILER_DIR ?= /usr/bin
+AS = $(COMPILER_DIR)/gcc
+CC = $(COMPILER_DIR)/gcc
+CXX = $(COMPILER_DIR)/g++
+LINK = $(COMPILER_DIR)/g++
+DUMP = $(COMPILER_DIR)/objdump
+CC_O = -g -c -O0
+CXX_VER ?= -std=c++20
+else ifeq ($(PLAT), linx)
+DEFINES += -D__linx
+ifndef COMPILER_DIR
+$(error COMPILER_DIR is not set. Export COMPILER_DIR pointing to the linx_blockisa_llvm_musl toolchain bin directory)
+endif
+AS = $(COMPILER_DIR)/clang
+CC = $(COMPILER_DIR)/clang
+CXX = $(COMPILER_DIR)/clang++
+LINK = $(COMPILER_DIR)/clang++
+DUMP = $(COMPILER_DIR)/llvm-objdump
+CC_O = -c -mlxbc -fenable-matrix -O2 -mllvm -enable-all-vector-as-tilereg=true $(CFLAGS)
+CXX_VER ?= -std=c++20
+CC_LINK += -nostartfiles $(TEST_ROOT)/common/_start.s
+DEFINES += -DENABLE_TENSOR_INSTR
+# res_check precision path: bake the per-case compare dir + link the scalar
+# guard_io TU (fills/dump/read compiled WITHOUT matrix flags; see guard_io.h).
+DEFINES += -DRES_CHECK -DCHK_DIR=\"$(GUARD_ROOT)/compare/$(CATEGORY)/$(TESTCASE)\"
+GUARD_IO_OBJ := $(OBJ_ROOT)/tileop-test/guard_io.o
+endif
+
+# Include paths: test/common(+src) for benchmark.h etc. + tileop-test common
+INCLUDE += -I$(TEST_ROOT)/common -I$(TEST_ROOT)/common/src -I$(GUARD_ROOT)/common
+
+# Object file
+OBJ := $(patsubst %.cpp, %.o, $(subst $(SRC_DIR), $(OBJ_DIR), $(SRC_FILE)))
+
+CC_O_ALL = $(CC_O) $(CC_OPTS)
+CXX_O_ALL = $(CC_O) $(CXX_VER) $(CC_OPTS)
+
+.DEFAULT_GOAL := all
+
+all: pre_work $(TARGET)
+
+diss: pre_work $(TARGET)
+	$(DUMP) -dl $(TARGET) > $(TARGET).diss
+
+$(OBJ_DIR)%.o: $(SRC_DIR)%.cpp
+	@mkdir -p $(shell dirname $@)
+	$(CXX) $(CXX_O_ALL) $(INCLUDE) $(DEFINES) $< -o $@
+
+# guard_io: scalar helper TU compiled WITHOUT matrix flags (-mlxbc -O2 only),
+# via clang++ ($(CXX)) since -mlxbc pulls in the C++-only linx_blkc.h header.
+$(GUARD_IO_OBJ): $(GUARD_ROOT)/common/guard_io.c
+	@mkdir -p $(shell dirname $@)
+	$(CXX) -mlxbc -O2 $(CXX_VER) $(INCLUDE) -c $< -o $@
+
+$(TARGET): $(OBJ) $(GUARD_IO_OBJ)
+	@mkdir -p $(shell dirname $@)
+	$(LINK) $(CC_LINK) $(OBJ) $(GUARD_IO_OBJ) -o $@
+
+pre_work:
+	@mkdir -p $(OBJ_DIR)
+	@mkdir -p $(ELF_DIR)
+
+clean:
+	@find $(OBJ_ROOT)/tileop-test -type f -name "*.o" -exec rm -rf {} \; 2>/dev/null || true
+
+clean_all:
+	@rm -rf $(OBJ_ROOT)/tileop-test
+
+.PHONY: all diss clean clean_all pre_work

--- a/benchmark/one-level-arch/test/solution/tileop-test/README.md
+++ b/benchmark/one-level-arch/test/solution/tileop-test/README.md
@@ -1,0 +1,67 @@
+# tileop-guard —— PTO-ISA microbench API 精度看护
+
+对 PTO-ISA microbench（TileOP-API intrinsic）做**精度看护**：不仅验"能不能跑"（gfrun 通过），更验
+"算得对不对"——用 host 侧独立 golden 逐元素对照 **pto-spec 规范 ASL 定义的预期语义**。
+
+> 与 version-tracking / pr-tracking 的区别：那两个只看 gfrun/gfsim 是否 PASS；本套看逐元素数值正确性。
+
+## 判据：四态层层递进
+
+每个 case 停在能到达的最高层：
+
+1. **编译失败**（compile-fail）：工具链拒绝（header↔backend skew、后端缺 pattern 等）。
+2. **执行失败**（run-fail）：编译过、gfrun 崩（模型契约拒绝 / 未实现）。
+3. **精度失败**（precision-fail / witness）：跑通但输出与 golden 不符。golden 钉 pto-spec **预期**语义，
+   实现背离自然落此层 = **忠实暴露缺口，非回归**。
+4. **精度正确**（PASS）：功能 + 精度双看护通过。
+
+`run-only`：无可校数值输出的终态（纯搬运 tload/tstore/tmov/tprefetch）。
+
+## golden 纪律（关键）
+
+- golden 是 **host 侧独立 numpy oracle**，仅从**接口语义**（pto-spec 规范 ASL + intrinsic 文档）实现，
+  **不读模型实现** → 真正独立的参照。
+- golden 必须钉 **pto-spec 规范定义的预期语义**（写前先核实、别假设、别拟合模型观测行为）——否则会把
+  模型 bug 焊进 oracle，让看护对缺陷视而不见。
+- 输入由 host（numpy）生成并落盘（设备端填充会被 tile 后端错编）；ELF 整块 `read()` 读入。
+
+## 目录结构
+
+| 路径 | 说明 |
+|---|---|
+| `vec/ sfu/ cube/ fixp/ tlsu/ misc/` | 各域 demo（`src/*.cpp` + 每域 `Makefile`） |
+| `golden/golden.py` | host 独立 golden：`gen` 造输入 / `check` 校输出，`REG[case]` 注册每 case 语义 |
+| `common/` | 共享驱动模板 `guard_common.hpp` / `guard_case.hpp` + `guard_io`（无 printf 落盘） |
+| `retired/` | 已被 PTO-SPEC ADR 退休的直接 Tile op（隔离出活跃看护，fail-closed） |
+| `run_guard.sh` `env.sh` `Makefile.common` | 执行入口 |
+| `compare/` `output/` | 运行产物（gitignore，非提交） |
+
+## 执行方式
+
+```bash
+# 1. 指向 linx 工具链 + gfrun：export LINX_ROOT=<含 linx-toolchain-build/ 和 SuperScalarModel/ 的目录>
+#    （或直接 export COMPILER_DIR / GFRUN），再 source env.sh 生效
+export LINX_ROOT=/path/to/your/linx-root
+source benchmark/one-level-arch/test/solution/tileop-test/env.sh          # 设 COMPILER_DIR / GFRUN
+
+# 2. 跑单个 case
+bash benchmark/one-level-arch/test/solution/tileop-test/run_guard.sh <domain> <case>
+#   例: bash benchmark/one-level-arch/test/solution/tileop-test/run_guard.sh sfu tcolmax
+
+# 3. 跑整个域（domain ∈ vec/sfu/cube/fixp/tlsu/misc）
+bash benchmark/one-level-arch/test/solution/tileop-test/run_guard.sh <domain>
+```
+
+**res_check 精度流程（每 case）**：
+`golden.py gen`（造 `CHK_DIR/in_*.bin`，host 拥有输入）→ `make`（编译 ELF）→ `gfrun`（读 `in_*`、dump `out.bin`）
+→ `golden.py check`（numpy 独立逐元素对照，rc0=PASS / 非0=MISMATCH）。
+
+**输出列**：`compile | gfrun | precision`，落为四态 `compile-fail / run-fail / precision-fail / pass`
+（未注册 golden 的 case 显示 `run-only`）。失败 case 另落 `compare/<域>/<case>/{compile.log,gfrun.log}` +
+一条 `ERRSIG` token（报错点）。
+
+## 注意
+
+- **改共享头（`common/*.hpp`）后必须 clean 重编**：`run_guard.sh` 增量 make 只看 `.cpp`，旧 `.o` 会假崩/假过。
+- 判定前统一走同一套 linx 工具链 + gfrun；换工具链须干净重编。
+- golden 涉舍入/饱和/默认值时，必须回 pto-spec ASL 核实规范默认（别信经验拟合）。

--- a/benchmark/one-level-arch/test/solution/tileop-test/common/guard_case.hpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/common/guard_case.hpp
@@ -1,0 +1,94 @@
+#ifndef TILEOP_GUARD_CASE_HPP
+#define TILEOP_GUARD_CASE_HPP
+// res_check case macros. Each macro emits the whole demo body: file-scope
+// buffers (globals resist tile-register promotion) + main() that reads
+// host-generated inputs (CHK_DIR/in_*.bin) via read() syscall, runs the tile op
+// through a guard_common.hpp driver, and dumps CHK_DIR/out.bin for golden.py.
+// The op is passed as a lambda in __VA_ARGS__ (internal commas are fine).
+// See guard_io.h / project memory for why inputs are host-owned and dumps are
+// printf-free.
+#include "guard_common.hpp"
+#include "guard_io.h"
+
+#define GUARD_BINARY(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gB[(M) * (N)], gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    guard_read_bin(CHK_DIR "/in_b.bin", gB, sizeof(gB)); \
+    BENCHSTART; g_binary<DT, M, N>(gC, gA, gB, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#define GUARD_SCALAR(DT, M, N, SVAL, ...) \
+  static DT gA[(M) * (N)], gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    BENCHSTART; g_scalar<DT, M, N>(gC, gA, (DT)(SVAL), __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#define GUARD_UNARY(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    BENCHSTART; g_unary<DT, M, N>(gC, gA, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#define GUARD_UNARY_CVT(DIN, DOUT, M, N, ...) \
+  static DIN gA[(M) * (N)]; static DOUT gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    BENCHSTART; g_unary_cvt<DIN, DOUT, M, N>(gC, gA, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#define GUARD_TERNARY(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gB[(M) * (N)], gD[(M) * (N)], gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    guard_read_bin(CHK_DIR "/in_b.bin", gB, sizeof(gB)); \
+    guard_read_bin(CHK_DIR "/in_c.bin", gD, sizeof(gD)); \
+    BENCHSTART; g_ternary<DT, M, N>(gC, gA, gB, gD, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+// reduce: src M x N -> dst physical M x N with valid axis = 1 (row: ValidCol=1,
+// col: ValidRow=1). golden.py compares only the valid footprint.
+#define GUARD_ROWREDUCE(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gC[(M) * 1]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    BENCHSTART; g_rowreduce<DT, M, N>(gC, gA, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#define GUARD_COLREDUCE(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gC[1 * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    BENCHSTART; g_colreduce<DT, M, N>(gC, gA, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+// expand-arith: dst = op(src0 MxN, src1 broadcast). row: src1 is Mx1 col-bcast;
+// col: src1 is 1xN row-bcast (physical MxN, ValidRow=1). golden.py broadcasts.
+#define GUARD_ROWEXPAND(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gB[(M) * 1], gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    guard_read_bin(CHK_DIR "/in_b.bin", gB, sizeof(gB)); \
+    BENCHSTART; g_rowexpand<DT, M, N>(gC, gA, gB, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#define GUARD_COLEXPAND(DT, M, N, ...) \
+  static DT gA[(M) * (N)], gB[1 * (N)], gC[(M) * (N)]; \
+  int main() { \
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA)); \
+    guard_read_bin(CHK_DIR "/in_b.bin", gB, sizeof(gB)); \
+    BENCHSTART; g_colexpand<DT, M, N>(gC, gA, gB, __VA_ARGS__); BENCHEND; \
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC)); \
+    return 0; }
+
+#endif  // TILEOP_GUARD_CASE_HPP

--- a/benchmark/one-level-arch/test/solution/tileop-test/common/guard_common.hpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/common/guard_common.hpp
@@ -1,0 +1,250 @@
+#ifndef TILEOP_GUARD_COMMON_HPP
+#define TILEOP_GUARD_COMMON_HPP
+
+// ---------------------------------------------------------------------------
+// TileOP-API v0.58 documentation guard demos.
+//
+// GROUND RULE: every demo is written STRICTLY from the prose/examples in
+//   Linx-TileOP-API/docs/tileop-usage/*.md
+// We do NOT read the intrinsic source headers to discover usage; the whole
+// point is to test whether the documentation alone is sufficient to drive a
+// correct call. Canonical v0.58 uppercase names are used (TADD, TMATMUL, ...),
+// never the historical PTO-0.57 shims (TSELECT / TEXPANDSCALAR / ...).
+//
+// A demo "passes" when it compiles to an .elf and gfrun runs it to normal
+// exit (no crash / assert). No numeric golden check -- this is a toolchain +
+// simulator stability guard, per task scope.
+// ---------------------------------------------------------------------------
+
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+#include "benchmark.h"
+
+using namespace pto;
+
+// ---- data init helpers (host arrays feeding TLOAD) ----
+template <typename T>
+static inline void gfill_seq(T *p, int n, T base = (T)0) {
+    for (int i = 0; i < n; ++i) p[i] = (T)(base + (T)i * (T)0.1);
+}
+template <typename T>
+static inline void gfill_const(T *p, int n, T v) {
+    for (int i = 0; i < n; ++i) p[i] = v;
+}
+template <typename T>
+static inline void gzero(T *p, int n) { gfill_const(p, n, (T)0); }
+// index / offset fill for gather/scatter style ops
+template <typename T>
+static inline void gfill_idx(T *p, int n, T base = (T)0) {
+    for (int i = 0; i < n; ++i) p[i] = (T)((i * 7) % n) + base;
+}
+
+// ---- common tile / global aliases (RowMajor, VEC location) ----
+template <typename D, int M, int N>
+using gm_t = global_tensor<D, RowMajor<M, N>>;
+template <typename D, int M, int N>
+using vtile_t = Tile<Location::Vec, D, M, N, BLayout::RowMajor>;
+template <typename D, int M, int N>
+using iter_t = global_iterator<gm_t<D, M, N>, vtile_t<D, M, N>>;
+
+// ---------------------------------------------------------------------------
+// Driver templates. Only the plumbing (TLOAD -> op -> TSTORE, documented in
+// tlsu.md) is templated; the actual intrinsic call arrives as a lambda that
+// each case writes STRICTLY from the docs. dtypes may differ between src and
+// dst (e.g. TCVT, TCMP), so the load/store tiles are typed independently.
+// ---------------------------------------------------------------------------
+
+// dst = op(src0) ; same in/out dtype
+template <typename D, int M, int N, typename Op>
+void g_unary(D *c, const D *a, Op op) {
+    iter_t<D, M, N> gA((D *)a), gC(c);
+    auto gA0 = gA(0, 0), gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA, tC;
+    TLOAD(tA, gA0);
+    op(tC, tA);
+    TSTORE(gC0, tC);
+}
+
+// dst = op(src0, src1) ; same dtype
+template <typename D, int M, int N, typename Op>
+void g_binary(D *c, const D *a, const D *b, Op op) {
+    iter_t<D, M, N> gA((D *)a), gB((D *)b), gC(c);
+    auto gA0 = gA(0, 0), gB0 = gB(0, 0), gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA, tB, tC;
+    TLOAD(tA, gA0);
+    TLOAD(tB, gB0);
+    op(tC, tA, tB);
+    TSTORE(gC0, tC);
+}
+
+// dst = op(src0, src1, src2) ; same dtype
+template <typename D, int M, int N, typename Op>
+void g_ternary(D *c, const D *a, const D *b, const D *d, Op op) {
+    iter_t<D, M, N> gA((D *)a), gB((D *)b), gD((D *)d), gC(c);
+    auto gA0 = gA(0, 0), gB0 = gB(0, 0), gD0 = gD(0, 0), gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA, tB, tD, tC;
+    TLOAD(tA, gA0);
+    TLOAD(tB, gB0);
+    TLOAD(tD, gD0);
+    op(tC, tA, tB, tD);
+    TSTORE(gC0, tC);
+}
+
+// dst = op(src0, scalar)
+template <typename D, int M, int N, typename Op>
+void g_scalar(D *c, const D *a, D s, Op op) {
+    iter_t<D, M, N> gA((D *)a), gC(c);
+    auto gA0 = gA(0, 0), gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA, tC;
+    TLOAD(tA, gA0);
+    op(tC, tA, s);
+    TSTORE(gC0, tC);
+}
+
+// dst = op(src0)  with distinct out dtype (TCVT / TCMP-style)
+template <typename DIn, typename DOut, int M, int N, typename Op>
+void g_unary_cvt(DOut *c, const DIn *a, Op op) {
+    iter_t<DIn, M, N> gA((DIn *)a);
+    iter_t<DOut, M, N> gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<DIn, M, N> tA;
+    vtile_t<DOut, M, N> tC;
+    TLOAD(tA, gA0);
+    op(tC, tA);
+    TSTORE(gC0, tC);
+}
+
+// dst = op(src0, src1)  with distinct out dtype (TCMP: bool/int out)
+template <typename DIn, typename DOut, int M, int N, typename Op>
+void g_binary_cvt(DOut *c, const DIn *a, const DIn *b, Op op) {
+    iter_t<DIn, M, N> gA((DIn *)a), gB((DIn *)b);
+    iter_t<DOut, M, N> gC(c);
+    auto gA0 = gA(0, 0);
+    auto gB0 = gB(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<DIn, M, N> tA, tB;
+    vtile_t<DOut, M, N> tC;
+    TLOAD(tA, gA0);
+    TLOAD(tB, gB0);
+    op(tC, tA, tB);
+    TSTORE(gC0, tC);
+}
+
+// dst = op(src0, scalar)  with distinct out dtype (TCMPS)
+template <typename DIn, typename DOut, int M, int N, typename Op>
+void g_scalar_cvt(DOut *c, const DIn *a, DIn s, Op op) {
+    iter_t<DIn, M, N> gA((DIn *)a);
+    iter_t<DOut, M, N> gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<DIn, M, N> tA;
+    vtile_t<DOut, M, N> tC;
+    TLOAD(tA, gA0);
+    op(tC, tA, s);
+    TSTORE(gC0, tC);
+}
+
+// ---------------------------------------------------------------------------
+// Reduce / expand drivers. Row-reduce collapses columns -> M x 1 output;
+// col-reduce collapses rows -> 1 x N output. Output valid dim is 1 on the
+// reduced axis (matches the reference tree's bench_reduce ValidCol==1 rule).
+// Docs give NO signatures for the TROW*/TCOL* family; shapes here are inferred
+// and corrected from compiler / gfrun feedback (recorded in REPORT.md).
+// ---------------------------------------------------------------------------
+
+// row reduce: src M x N  ->  dst GENUINE M x 1 (Cols==1).
+// ops-20260904 TileOP-API (f8fb894) added a static_assert requiring the
+// row-reduce destination to be a real single-column tile
+// (ValidCol==1 && Cols==1); the historical "physical M x N + ValidCol=1"
+// workaround now fails to compile. The paired model lifted the old fp32
+// Cols%8 store constraint for reduce outputs.
+template <typename D, int M, int N, typename Op>
+void g_rowreduce(D *c, const D *a, Op op) {
+    // ops-20260904 TileOP-API (f8fb894) requires the row-reduce dst to be a
+    // GENUINE single-column tile (ValidCol==1 && Cols==1); the historical
+    // physical M x N + ValidCol=1 workaround now fails to compile. Mirror the
+    // release reference kernel (reducemax_rowvec.hpp): static M x N source,
+    // genuine M x 1 dst, M x 1 output global.
+    using OutTile = Tile<Location::Vec, D, M, 1, BLayout::RowMajor, M, 1>;
+    iter_t<D, M, N> gA((D *)a);
+    global_iterator<gm_t<D, M, 1>, OutTile> gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA;
+    OutTile tC;
+    TLOAD(tA, gA0);
+    op(tC, tA);
+    TSTORE(gC0, tC);
+}
+
+// col reduce: src M x N  ->  dst GENUINE 1 x N (Rows==1).
+// ops-20260904 model writes col reductions into a real single-row 1 x N tile
+// (release reference reducemax_colvec.hpp: dst Tile<Vec,dtype,1,tN,RowMajor>,
+// output global RowMajor<1,gIN>). The historical physical M x N + ValidRow=1
+// workaround made the harness read stale row-0 bytes (got=1.0), so use the
+// genuine 1 x N geometry.
+template <typename D, int M, int N, typename Op>
+void g_colreduce(D *c, const D *a, Op op) {
+    using OutTile = Tile<Location::Vec, D, 1, N, BLayout::RowMajor>;
+    iter_t<D, M, N> gA((D *)a);
+    global_iterator<gm_t<D, 1, N>, OutTile> gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA;
+    OutTile tC;
+    TLOAD(tA, gA0);
+    op(tC, tA);
+    TSTORE(gC0, tC);
+}
+
+// ---------------------------------------------------------------------------
+// Expand-arith drivers. TROWEXPAND*/TCOLEXPAND* fuse a broadcast + binary op.
+// gfrun asserts the broadcast source shape:
+//   row-expand: srcs[2] must be a validRow x 1 (M x 1) column broadcast source.
+//   col-expand: srcs[2] must be a 1 x validCol (1 x N) row broadcast source.
+// Docs give NO signature or shape rule for these; inferred from gfrun feedback
+// (recorded in REPORT.md as a documentation gap).
+// dst = op(src0 M x N, src1_broadcast) -> M x N.
+// ---------------------------------------------------------------------------
+
+// row-expand: src1 must be a PHYSICAL M x 1 column broadcast source. gfrun
+// asserts physicalCol==1 (IsCompatibleDataTile(srcs[2],...,validRow,1,1,...)),
+// so a physical M x N tile with ValidCol=1 is REJECTED here (unlike col-expand,
+// which accepts a physical M x N ValidRow=1 source). Asymmetry recorded in REPORT.
+template <typename D, int M, int N, typename Op>
+void g_rowexpand(D *c, const D *a, const D *b, Op op) {
+    using BcastTile = vtile_t<D, M, 1>;
+    iter_t<D, M, N> gA((D *)a), gC(c);
+    iter_t<D, M, 1> gB((D *)b);
+    auto gA0 = gA(0, 0);
+    auto gB0 = gB(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA, tC;
+    BcastTile tB;
+    TLOAD(tA, gA0);
+    TLOAD(tB, gB0);
+    op(tC, tA, tB);
+    TSTORE(gC0, tC);
+}
+
+// col-expand: src1 is a GENUINE 1 x N row broadcast source (对齐 TCOLEXPAND.md 示例，
+// 与 g_rowexpand 的 M x 1 对称)。spec TCOLEXPAND.asl: 源逻辑 ValidRow==1/ValidCol==dst，
+// 物理 extents 由 layout 派生 —— 真 1 x N 合法(实测编译+跑通+结果正确)。
+template <typename D, int M, int N, typename Op>
+void g_colexpand(D *c, const D *a, const D *b, Op op) {
+    using BcastTile = vtile_t<D, 1, N>;                 // GENUINE 1 x N
+    iter_t<D, M, N> gA((D *)a), gC(c);
+    iter_t<D, 1, N> gB((D *)b);
+    auto gA0 = gA(0, 0);
+    auto gB0 = gB(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<D, M, N> tA, tC;
+    BcastTile tB;
+    TLOAD(tA, gA0);
+    TLOAD(tB, gB0);
+    op(tC, tA, tB);
+    TSTORE(gC0, tC);
+}
+
+#endif  // TILEOP_GUARD_COMMON_HPP

--- a/benchmark/one-level-arch/test/solution/tileop-test/common/guard_io.c
+++ b/benchmark/one-level-arch/test/solution/tileop-test/common/guard_io.c
@@ -1,0 +1,47 @@
+// Compiled WITHOUT matrix flags (-mlxbc -O2 only) so these loops stay scalar.
+// See guard_io.h for the rationale.
+#include "guard_io.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+void guard_fill_seq_f32(float* p, int n, float base, float step) {
+    for (int i = 0; i < n; ++i) p[i] = base + (float)i * step;
+}
+
+void guard_fill_const_f32(float* p, int n, float v) {
+    for (int i = 0; i < n; ++i) p[i] = v;
+}
+
+void guard_fill_seq_i32(int32_t* p, int n, int32_t base, int32_t step) {
+    for (int i = 0; i < n; ++i) p[i] = base + i * step;
+}
+
+void guard_fill_seq_f16(uint16_t* p, int n, float base, float step) {
+    for (int i = 0; i < n; ++i) {
+        __fp16 h = (__fp16)(base + (float)i * step);
+        uint16_t bits;
+        memcpy(&bits, &h, sizeof(bits));
+        p[i] = bits;
+    }
+}
+
+void guard_dump_bin(const char* path, const void* p, size_t bytes) {
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) return;
+    (void)write(fd, p, bytes);
+    close(fd);
+}
+
+void guard_read_bin(const char* path, void* p, size_t bytes) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) return;
+    size_t done = 0;
+    char* d = (char*)p;
+    while (done < bytes) {
+        long r = read(fd, d + done, bytes - done);
+        if (r <= 0) break;
+        done += (size_t)r;
+    }
+    close(fd);
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/common/guard_io.h
+++ b/benchmark/one-level-arch/test/solution/tileop-test/common/guard_io.h
@@ -1,0 +1,33 @@
+#ifndef TILEOP_GUARD_IO_H
+#define TILEOP_GUARD_IO_H
+// Host-side input generation + raw binary dump for the res_check precision path.
+//
+// These live in guard_io.c, compiled WITHOUT the matrix flags
+// (-fenable-matrix / -enable-all-vector-as-tilereg). That isolation is load-
+// bearing: when the fill loops are compiled with the matrix flags they get
+// promoted to tile registers and the host arrays degenerate (e.g. a[] collapses
+// to a single non-zero element), producing weak/degenerate test vectors. The
+// dumper likewise avoids libc printf (writeBinaryFile's trailing printf/fflush
+// hangs gfrun); raw open/write/close via the emulator syscall passthrough works.
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Deterministic, varied fills (stay scalar; safe to dump + recompute host-side).
+void guard_fill_seq_f32(float* p, int n, float base, float step);
+void guard_fill_const_f32(float* p, int n, float v);
+void guard_fill_seq_i32(int32_t* p, int n, int32_t base, int32_t step);
+void guard_fill_seq_f16(uint16_t* p, int n, float base, float step);  // raw __half bits
+
+// Raw binary dump (no printf). Silently no-ops on open failure.
+void guard_dump_bin(const char* path, const void* p, size_t bytes);
+
+// Raw binary read (host-generated inputs). Silently no-ops on open failure.
+void guard_read_bin(const char* path, void* p, size_t bytes);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // TILEOP_GUARD_IO_H

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/Makefile
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/Makefile
@@ -1,0 +1,3 @@
+SRC_FILE = src/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)/$(TESTCASE).elf
+include ../Makefile.common

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tgemv.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tgemv.cpp
@@ -1,0 +1,33 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TGEMV (CUBE) — D(1,N) = Vec(1,K) * Mtx(K,N), M=1.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — TGEMV(Dst, Mtx, Vec, options);
+//   Vec=CubeTileM16<T,1,K>, Mtx=CubeTileN8<T,K,N>, Dst=CubeAccumulatorM16<AccT,1,N>.
+//   数学源顺序 A=Vec, B=Mtx；Local-only（任何 B.IOS illegal）。
+// Precision: res_check, f16 vec/mtx host-generated, independent numpy golden
+//   (fam='matmul' M=1: D = vec(1,K) @ mtx(K,N)); in_a=vec, in_b=mtx.
+constexpr int GN = 32, GK = 32;
+static __half hv[1 * GK], hm[GK * GN];
+static float  hd[1 * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", hv, sizeof(hv));
+    guard_read_bin(CHK_DIR "/in_b.bin", hm, sizeof(hm));
+    CubeTileM16<__half, 1, GK> vec;
+    CubeTileN8<__half, GK, GN>  mtx;
+    // doc says Dst = CubeAccumulatorM16<AccT,1,N>. gfrun 断言要求物理 col>=N
+    // 且维度为 2 的幂、dst 容量 >= M x N 输出区。M=1,N=32 已是 2 的幂。
+    CubeAccumulatorM16<float, 1, GN> d;
+
+    global_tensor<__half, RowMajor<1, GK>> gV(hv);
+    global_tensor<__half, RowMajor<GK, GN>> gM(hm);
+    global_tensor<float,  RowMajor<1, GN>> gD(hd);
+
+    TLOAD_CUBE(vec, gV);
+    TLOAD_CUBE(mtx, gM);
+    BENCHSTART;
+    TGEMV(d, mtx, vec, fixp::keep_acc());   // doc arg order: (Dst, Mtx, Vec, options)
+    BENCHEND;
+    TSTORE_CUBE(gD, d);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul.cpp
@@ -1,0 +1,30 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL (CUBE) — D = A*B.
+// Source: docs/tileop-usage/cube.md + options.md（+ pto-spec matrix-postprocess.asl）.
+//   CubeTileM32<T,M,K> a; CubeTileN8<T,K,N> b; CubeAccumulatorM32<AccT,M,N> out;
+//   TMATMUL(out,a,b); GM 边界用 TLOAD_CUBE/TSTORE_CUBE。
+// NOTE(doc-gap 已修复, API 0566283): 早期 TLOAD_CUBE/TSTORE_CUBE 无 C++ 签名(当时推断)。
+//   现 TLOAD.md:21 / TSTORE.md:23 已给签名+参数序 (cube_tile, global_tensor),与本 demo 一致。
+// Precision: res_check, f16 A/B host-generated, independent numpy golden (f32 @).
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN];
+static float  hc[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<float, GM, GN> out;
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<float,  RowMajor<GM, GN>> gC(hc);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b);
+    BENCHEND;
+    TSTORE_CUBE(gC, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_acc.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_acc.cpp
@@ -1,0 +1,30 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL_ACC (CUBE) — D = C + A*B.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — TMATMUL_ACC(Dst, C, A, B, options);
+//   .ACC 读显式累加器 C 作首源，写独立 D。无 options 等价 keep_acc()。
+// Precision: res_check, host-generated A/B(f16)+C(f32), golden D = C + A@B.
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN];
+static float  hcc[GM * GN], hd[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    guard_read_bin(CHK_DIR "/in_c.bin", hcc, sizeof(hcc));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<float, GM, GN> c, d;
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<float,  RowMajor<GM, GN>> gC(hcc);
+    global_tensor<float,  RowMajor<GM, GN>> gD(hd);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD_CUBE(c, gC);
+    BENCHSTART;
+    TMATMUL_ACC(d, c, a, b, fixp::keep_acc());
+    BENCHEND;
+    TSTORE_CUBE(gD, d);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_bf16.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_bf16.cpp
@@ -1,0 +1,27 @@
+#include "guard_common.hpp"
+// TileOP-API doc guard: TMATMUL + fixp::bf16() — D = A*B, PreQuant F322BF16.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） line 164 — TMATMUL(dst_bf16, a, b, fixp::bf16());
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    __bf16 hd[M * N];
+    for (int i = 0; i < M * K; ++i) ha[i] = (__half)(0.01f * i);
+    for (int i = 0; i < K * N; ++i) hb[i] = (__half)(0.02f * i);
+    for (int i = 0; i < M * N; ++i) hd[i] = (__bf16)0.0f;
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<__bf16, M, N> out;    // dst dtype BF16 per options 表
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<__bf16, RowMajor<M, N>> gD(hd);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::bf16());
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_bias.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_bias.cpp
@@ -1,0 +1,36 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL_BIAS (CUBE) — D = A*B + Bias.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — TMATMUL_BIAS<Attr>(Dst, A, B, Bias, options).
+// NOTE(doc-gap 已修复, API 0566283): 早期文档只说 Bias 是"普通 Local Tile",约束靠 static_assert 反推。
+//   现 TMATMUL_BIAS.md:51-56 已明确:普通 RowMajor Tile + dtype=FP32(同 accumulator) + valid 固定 1×N +
+//   用普通 TLOAD(非 TLOAD_CUBE)。**bias 已对齐文档示例 Location::Bias(2026-09-08)**:spec TMATMUL_BIAS.asl
+//   只要求"ordinary Local row-major 1xN accumulator型"(未限 location);Location::Vec 与 Location::Bias 经
+//   指令级 diff 证发射 tile bundle 完全相同(bias role 由参数位置定),两者等价,此处采用文档示例的 Location::Bias。
+// Precision: res_check, golden = A@B + bias(1xN broadcast).
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN];
+static float  hbias[GN], hc[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    guard_read_bin(CHK_DIR "/in_bias.bin", hbias, sizeof(hbias));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    Tile<Location::Bias, float, 1, GN, BLayout::RowMajor> bias;  // 对齐 TMATMUL_BIAS.md 示例 Location::Bias
+    CubeAccumulatorM32<float, GM, GN> out;
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    iter_t<float, 1, GN> gBias(hbias);
+    auto gBias0 = gBias(0, 0);
+    global_tensor<float,  RowMajor<GM, GN>> gC(hc);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD(bias, gBias0);                            // ordinary Local tile load
+    BENCHSTART;
+    TMATMUL_BIAS(out, a, b, bias, fixp::keep_acc());
+    BENCHEND;
+    TSTORE_CUBE(gC, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_f16.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_f16.cpp
@@ -1,0 +1,26 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL + fixp::f16() — D = A*B, PreQuant F322F16.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） line 163 — TMATMUL(dst_fp16, a, b, fixp::f16());
+//   options 表: fixp::f16() -> PreQuantMode F322F16, dst dtype FP16.
+// Precision: res_check, golden = (A@B) cast to f16.
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN], hd[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<__half, GM, GN> out;    // dst dtype FP16 per options 表
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<__half, RowMajor<GM, GN>> gD(hd);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::f16());
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_mx.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_mx.cpp
@@ -1,0 +1,30 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL_MX (CUBE) — FP16/BF16 pair, no scales.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — TMATMUL_MX(Dst, A, B, options); // no scales
+//   MX 的 FP16/BF16 侧不得提供 scale；便捷重载省去 scale operand。
+// Precision: res_check, f16 A/B host-generated, independent numpy golden
+//   (fam='matmul': D = A(M,K) @ B(K,N)); MX f16 pair == plain matmul math.
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN];
+static float  hd[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<float, GM, GN> d;
+
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<float,  RowMajor<GM, GN>> gD(hd);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL_MX(d, a, b, fixp::keep_acc());   // FP16 pair: no scales
+    BENCHEND;
+    TSTORE_CUBE(gD, d);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_relu.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_relu.cpp
@@ -1,0 +1,25 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL + fixp::f16().relu() — PreQuant + ReLU 链式。
+// Source: options.md（+ pto-spec matrix-postprocess.asl） line 178 — TMATMUL(dst_fp16, a, b, fixp::f16().relu());
+// Precision: res_check, golden = relu(A@B) cast to f16.
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN], hd[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<__half, GM, GN> out;
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<__half, RowMajor<GM, GN>> gD(hd);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::f16().relu());
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_rowmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/cube/src/tmatmul_rowmax.cpp
@@ -1,0 +1,30 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMATMUL + RowMax postprocess.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — fixp::keep_acc().row_max(row_max_out).
+//   row_max_tile: Tile<Vec, float, 32, 8, RowMajor, 32, 1> (valid M x 1, 物理 >=128B).
+//   RowMaxEn=1, RowMaxInit=0. dtype 必须精确匹配派生 AccType(FP32)。
+// Precision: res_check, golden checks the accumulator out = A@B (row_max side
+// output is not dumped).
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN];
+static float  hc[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<float, GM, GN> out;
+    Tile<Location::Vec, float, 32, 8, BLayout::RowMajor, 32, 1> row_max_out;
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<float,  RowMajor<GM, GN>> gC(hc);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::keep_acc().row_max(row_max_out));
+    BENCHEND;
+    TSTORE_CUBE(gC, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/env.sh
+++ b/benchmark/one-level-arch/test/solution/tileop-test/env.sh
@@ -1,0 +1,13 @@
+# Source before running the guard: `source env.sh`
+#
+# Point at your linx toolchain (linx_blockisa_llvm_musl) + SuperScalarModel build.
+# Two ways:
+#   A) export COMPILER_DIR / GFRUN (and optionally GFSIM) yourself; or
+#   B) export LINX_ROOT = the directory that contains linx-toolchain-build/ and
+#      SuperScalarModel/, then source this file to derive the paths below.
+if [ -n "${LINX_ROOT:-}" ]; then
+  export COMPILER_DIR="${COMPILER_DIR:-$LINX_ROOT/linx-toolchain-build/output/linx_blockisa_llvm_musl/bin}"
+  export GFRUN="${GFRUN:-$LINX_ROOT/SuperScalarModel/bin/gfrun}"
+  export GFSIM="${GFSIM:-$LINX_ROOT/SuperScalarModel/bin/gfsim}"
+fi
+# run_guard.sh errors out if COMPILER_DIR / GFRUN are still unset.

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/Makefile
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/Makefile
@@ -1,0 +1,3 @@
+SRC_FILE = src/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)/$(TESTCASE).elf
+include ../Makefile.common

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/chain.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/chain.cpp
@@ -1,0 +1,45 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: chained RowMax + GroupMax + MaxAbs postprocess.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "RowMax + GroupMax + MaxAbs"
+//   fixp::keep_acc().row_max(in,out).group_max<8>(gout).max_abs().
+// Precision: res_check. RowMaxOut/GroupMaxOut are auxiliary destinations; the main
+//   D committed to gC is the plain fp32 matmul (postprocess.asl identity on D for
+//   pre_quant_mode==0). Golden = A@B. Guards that the full reduction chain does not
+//   corrupt D.
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    float  hc[M * N], hrmi[M * 8];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    gzero(hc, M * N);
+    for (int i = 0; i < M * 8; ++i) hrmi[i] = 0.0f;
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<float, M, N> out;
+    using RMTile = Tile<Location::Vec, float, 32, 8, BLayout::RowMajor, 32, 1>;
+    RMTile row_max_in, row_max_out;
+    Tile<Location::Vec, float, 32, 8, BLayout::RowMajor, 32, 4> group_max_out;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<float,  RowMajor<M, N>> gC(hc);
+    global_iterator<gm_t<float, 32, 8>, RMTile> gRMI(hrmi);
+    auto gRMI0 = gRMI(0, 0);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD(row_max_in, gRMI0);
+    BENCHSTART;
+    TMATMUL(out, a, b,
+            fixp::keep_acc()
+                .row_max(row_max_in, row_max_out)
+                .group_max<8>(group_max_out)
+                .max_abs());
+    BENCHEND;
+    TSTORE_CUBE(gC, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/convert.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/convert.cpp
@@ -1,0 +1,26 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::convert<Mode>() — generic parameter-free PreQuant.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — fixp::convert<FixpPreQuantMode::F322F16>() ->
+//   PreQuant F322F16, dst FP16. Equivalent to fixp::f16(); exercises generic convert<>.
+// Precision: res_check, golden = (A@B) cast to f16.
+constexpr int GM = 32, GN = 32, GK = 32;
+static __half ha[GM * GK], hb[GK * GN], hd[GM * GN];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    CubeTileM32<__half, GM, GK> a;
+    CubeTileN8<__half, GK, GN>  b;
+    CubeAccumulatorM32<__half, GM, GN> out;    // dst FP16 per B.FPATR 表
+    global_tensor<__half, RowMajor<GM, GK>> gA(ha);
+    global_tensor<__half, RowMajor<GK, GN>> gB(hb);
+    global_tensor<__half, RowMajor<GM, GN>> gD(hd);
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::convert<FixpPreQuantMode::F322F16>());
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/cscale.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/cscale.cpp
@@ -1,0 +1,42 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::keep_acc().cscale(scale) — FP32 accumulator C scaling.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "FP32 accumulator C scaling (PTO ISA 0.58.4)".
+// Precision: res_check. pto-spec cube.asl MatrixInitialAccumulatorValue applies the
+//   per-row U8 exponent to the initial accumulator C: TileProfileMatrixCScale =
+//   C / 2^exponent (matrix-postprocess.asl). Then A@B accumulates on top:
+//     d = A@B + C / 2^exp.  Here exp=1 (all rows) -> d = A@B + C/2. Golden = that.
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half  ha[M * K], hb[K * N];
+    float   hcc[M * N], hd[M * N];
+    uint8_t hs[32 * 32];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    guard_read_bin(CHK_DIR "/in_c.bin", hcc, sizeof(hcc));
+    gzero(hd, M * N);
+    for (int i = 0; i < 32 * 32; ++i) hs[i] = 1;      // per-row exponent 1 -> C/2
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<float, M, N> c, d;
+    // CScale: Local U8 CUBE_M32, valid M x 1
+    Tile<Location::Vec, uint8_t, 32, 32, BLayout::CubeM32, 32, 1> scale;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<float,  RowMajor<M, N>> gC(hcc);
+    global_tensor<float,  RowMajor<M, N>> gD(hd);
+    global_tensor<uint8_t, RowMajor<32, 32>> gS(hs);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD_CUBE(c, gC);
+    TLOAD_CUBE(scale, gS);
+    BENCHSTART;
+    TMATMUL_ACC(d, c, a, b, fixp::keep_acc().cscale(scale));
+    BENCHEND;
+    TSTORE_CUBE(gD, d);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/group_max.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/group_max.cpp
@@ -1,0 +1,34 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::keep_acc().group_max<GroupN>(out) — GroupMax reduction.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "GroupMax" (N=32, GroupN=8 -> valid columns = 4).
+// Precision: res_check. GroupMaxOut goes to a separate auxiliary destination; the
+//   main D committed to gC is the plain fp32 matmul (postprocess.asl identity on D
+//   for pre_quant_mode==0). Golden = A@B.
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    float  hc[M * N];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    gzero(hc, M * N);
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<float, M, N> out;
+    // GroupMax out: 物理 32x8, valid 32x4 (N/GroupN = 32/8)
+    Tile<Location::Vec, float, 32, 8, BLayout::RowMajor, 32, 4> group_max_out;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<float,  RowMajor<M, N>> gC(hc);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::keep_acc().group_max<8>(group_max_out));
+    BENCHEND;
+    TSTORE_CUBE(gC, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/lrelu.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/lrelu.cpp
@@ -1,0 +1,38 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::s8(desc).lrelu(fp19) — scalar quant + scalar LReLU.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "LReLU" (lrelu_fp19 low 19 bits).
+// Precision: res_check. pto-spec matrix-postprocess.asl folds scale+activation into
+//   one multiplier: value>=0 -> scale, value<0 -> lrelu slope (REPLACES scale).
+//   Then S9 round+sat -> +offset -> encode S8. FP19 scale 16.0, offset 5, slope 8.0.
+static constexpr uint64_t make_s8_quant(uint32_t fp19_scale, int16_t offset) {
+    return (static_cast<uint64_t>(fp19_scale & 0x7ffff) << 13) |
+           ((static_cast<uint64_t>(offset) & 0x1ff) << 37);
+}
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    int8_t hd[M * N];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    for (int i = 0; i < M * N; ++i) hd[i] = 0;
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<int8_t, M, N> out;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<int8_t, RowMajor<M, N>> gD(hd);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    const uint64_t quant_desc = make_s8_quant(0x20C00u, 5);   // FP19 16.0, offset 5
+    const uint64_t lrelu_fp19 = 0x20800u & 0x7ffffu;          // FP19 slope 8.0
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::s8(quant_desc).lrelu(lrelu_fp19));
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/prelu.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/prelu.cpp
@@ -1,0 +1,38 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::f16().prelu(tile) — convert + PReLU (no quant).
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "PReLU" (length-N FP19 Tile, low 19 bits = slope).
+// Precision: res_check. fixp::f16() convert has scale 1.0; pto-spec
+//   matrix-postprocess.asl multiplier: value>=0 -> 1.0, value<0 -> slope. F16
+//   floating encode: dst = fp16(where(D>=0, D, D*slope)). Slope FP19 0.5 per column.
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N], hd[M * N];
+    uint64_t hp[2 * 32];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    for (int i = 0; i < M * N; ++i) hd[i] = (__half)0.0f;
+    for (int i = 0; i < 2 * 32; ++i) hp[i] = 0x1F800u & 0x7ffffu;   // FP19 slope 0.5
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<__half, M, N> out;
+    using Fp19Tile = Tile<Location::Vec, uint64_t, 2, 32, BLayout::RowMajor, 1, 32>;
+    Fp19Tile prelu;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<__half, RowMajor<M, N>> gD(hd);
+    global_iterator<gm_t<uint64_t, 2, 32>, Fp19Tile> gP(hp);
+    auto gP0 = gP(0, 0);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD(prelu, gP0);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::f16().prelu(prelu));
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/rowmax_acc.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/rowmax_acc.cpp
@@ -1,0 +1,39 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::keep_acc().row_max(in, out) — accumulate existing RowMax.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "累加已有 RowMax" (RowMaxEn=1, RowMaxInit=1).
+// Precision: res_check. keep_acc + RowMax publishes the *auxiliary* RowMaxOut to a
+//   separate destination; the main D committed to gC is the plain fp32 matmul
+//   (pto-spec postprocess.asl: pre_quant_mode==0 -> identity on D). Golden = A@B.
+//   RowMaxIn is host-zero (unused by the main-D golden).
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    float  hc[M * N], hrmi[M * 8];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    gzero(hc, M * N);
+    for (int i = 0; i < M * 8; ++i) hrmi[i] = 0.0f;
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<float, M, N> out;
+    using RMTile = Tile<Location::Vec, float, 32, 8, BLayout::RowMajor, 32, 1>;
+    RMTile row_max_in, row_max_out;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<float,  RowMajor<M, N>> gC(hc);
+    global_iterator<gm_t<float, 32, 8>, RMTile> gRMI(hrmi);
+    auto gRMI0 = gRMI(0, 0);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD(row_max_in, gRMI0);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::keep_acc().row_max(row_max_in, row_max_out));
+    BENCHEND;
+    TSTORE_CUBE(gC, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/s8_scalar.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/s8_scalar.cpp
@@ -1,0 +1,38 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::s8(uint64_t) — scalar quant to S8 (QF322S8Pre).
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "Scalar quant descriptor"
+//   descriptor 布局(64-bit): FP19 scale [31:13], S8 offset(S9) [45:37].
+// Precision: res_check. Golden pins pto-spec matrix-postprocess.asl:
+//   D=A@B (fp32); act=D*scale; S9 round+sat -> +offset -> encode S8 (RNE).
+//   scale FP19 0x20C00 = 16.0 (D*16 in +-40, rich non-saturating S8), offset 5.
+static constexpr uint64_t make_s8_quant(uint32_t fp19_scale, int16_t offset) {
+    return (static_cast<uint64_t>(fp19_scale & 0x7ffff) << 13) |
+           ((static_cast<uint64_t>(offset) & 0x1ff) << 37);
+}
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    int8_t hd[M * N];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    for (int i = 0; i < M * N; ++i) hd[i] = 0;
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<int8_t, M, N> out;    // dst S8 per B.FPATR 表
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<int8_t, RowMajor<M, N>> gD(hd);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    const uint64_t quant_desc = make_s8_quant(0x20C00u, 5);   // FP19 16.0, offset 5
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::s8(quant_desc));
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/s8_vector.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/s8_vector.cpp
@@ -1,0 +1,43 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::s8(tile) — vector-quant shortcut (VQF322S8Pre).
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "fixp::s8(quant) 是 VQF322S8Pre 的快捷形式".
+// Precision: res_check. Per-column FP19 scale + S9 offset; here uniform across
+//   columns (FP19 16.0, offset 5) so golden = spec scalar path per column
+//   (pto-spec matrix-postprocess.asl): act=D*scale; S9 round+sat -> +off -> S8.
+static constexpr uint64_t make_quant(uint32_t fp19_scale, int16_t offset) {
+    return (static_cast<uint64_t>(fp19_scale & 0x7ffff) << 13) |
+           ((static_cast<uint64_t>(offset) & 0x1ff) << 37);
+}
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    int8_t hd[M * N];
+    uint64_t hq[2 * 32];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    for (int i = 0; i < M * N; ++i) hd[i] = 0;
+    for (int i = 0; i < 2 * 32; ++i) hq[i] = make_quant(0x20C00u, 5);   // FP19 16.0, off 5
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<int8_t, M, N> out;
+    using QuantTile = Tile<Location::Vec, uint64_t, 2, 32, BLayout::RowMajor, 1, 32>;
+    QuantTile quant;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<int8_t, RowMajor<M, N>> gD(hd);
+    global_iterator<gm_t<uint64_t, 2, 32>, QuantTile> gQ(hq);
+    auto gQ0 = gQ(0, 0);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD(quant, gQ0);
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::s8(quant));   // vector-quant shortcut
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/scalar_generic.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/scalar_generic.cpp
@@ -1,0 +1,36 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::scalar<Mode>(descriptor) — generic scalar-param spelling.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — fixp::scalar<QF322S8Pre>(desc) == fixp::s8(desc).
+// Precision: res_check. Same spec math as s8_scalar (pto-spec matrix-postprocess.asl):
+//   act=D*scale; S9 round+sat -> +offset -> encode S8 (RNE). FP19 16.0, offset 5.
+static constexpr uint64_t make_s8_quant(uint32_t fp19_scale, int16_t offset) {
+    return (static_cast<uint64_t>(fp19_scale & 0x7ffff) << 13) |
+           ((static_cast<uint64_t>(offset) & 0x1ff) << 37);
+}
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N];
+    int8_t hd[M * N];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    for (int i = 0; i < M * N; ++i) hd[i] = 0;
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<int8_t, M, N> out;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<int8_t, RowMajor<M, N>> gD(hd);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    const uint64_t desc = make_s8_quant(0x20C00u, 5);   // FP19 16.0, offset 5
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::scalar<FixpPreQuantMode::QF322S8Pre>(desc));
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/vquant_f16.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/fixp/src/vquant_f16.cpp
@@ -1,0 +1,44 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: fixp::vector<Mode>(tile) — vector quant parameter to FP16.
+// Source: options.md（+ pto-spec matrix-postprocess.asl） — "Vector quant parameter"
+//   fixp::vector<VQF322F16Pre>(quant) -> dst FP16; each 64-bit element same bit
+//   layout as the scalar descriptor.
+// Precision: res_check. F16 (floating) path, offset unused; golden pins pto-spec
+//   matrix-postprocess.asl: dst = fp16(D * scale). FP19 16.0 per column.
+static constexpr uint64_t make_quant(uint32_t fp19_scale, int16_t offset) {
+    return (static_cast<uint64_t>(fp19_scale & 0x7ffff) << 13) |
+           ((static_cast<uint64_t>(offset) & 0x1ff) << 37);
+}
+int main() {
+    constexpr int M = 32, N = 32, K = 32;
+    __half ha[M * K], hb[K * N], hd[M * N];
+    uint64_t hq[2 * 32];
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    guard_read_bin(CHK_DIR "/in_b.bin", hb, sizeof(hb));
+    for (int i = 0; i < M * N; ++i) hd[i] = (__half)0.0f;
+    for (int i = 0; i < 2 * 32; ++i) hq[i] = make_quant(0x20C00u, 0);   // FP19 16.0
+
+    CubeTileM32<__half, M, K> a;
+    CubeTileN8<__half, K, N>  b;
+    CubeAccumulatorM32<__half, M, N> out;
+    // vector quant parameter tile: 物理 2x32 (>=128B), valid 1x32
+    using QuantTile = Tile<Location::Vec, uint64_t, 2, 32, BLayout::RowMajor, 1, 32>;
+    QuantTile quant;
+
+    global_tensor<__half, RowMajor<M, K>> gA(ha);
+    global_tensor<__half, RowMajor<K, N>> gB(hb);
+    global_tensor<__half, RowMajor<M, N>> gD(hd);
+    global_iterator<gm_t<uint64_t, 2, 32>, QuantTile> gQ(hq);
+    auto gQ0 = gQ(0, 0);
+
+    TLOAD_CUBE(a, gA);
+    TLOAD_CUBE(b, gB);
+    TLOAD(quant, gQ0);                 // ordinary Local tile load
+    BENCHSTART;
+    TMATMUL(out, a, b, fixp::vector<FixpPreQuantMode::VQF322F16Pre>(quant));
+    BENCHEND;
+    TSTORE_CUBE(gD, out);
+    guard_dump_bin(CHK_DIR "/out.bin", hd, sizeof(hd));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/golden/golden.py
+++ b/benchmark/one-level-arch/test/solution/tileop-test/golden/golden.py
@@ -1,0 +1,1530 @@
+#!/usr/bin/env python3
+"""Host-side independent golden for the tileop-guard res_check precision path.
+
+Two modes:
+  golden.py gen   <case> <chkdir>   # write CHK_DIR/in_*.bin (host owns inputs)
+  golden.py check <case> <chkdir>   # read in_*.bin + out.bin, compare, exit 0/1
+
+Independence principle: the reference is implemented here in numpy purely from
+the *interface semantics* (SuperNPUBench docs/intrinsics + SuperScalarModel ISA
+spec). It does NOT read the emulator's tile implementation, so it is a true
+independent oracle. Inputs are generated here (not on device) because the tile
+backend mangles device-side memory fills (see project memory / plan step 0).
+"""
+import sys, os
+import numpy as np
+
+# --------------------------------------------------------------------------
+# input generators (deterministic, varied, mixed-sign, non-degenerate).
+# div-family avoids zero divisors; shift-family clamps to [0,31].
+# --------------------------------------------------------------------------
+def seq_f32(n, base, step, seed=0):
+    i = np.arange(n, dtype=np.float32)
+    # mixed sign, non-monotone, nonzero
+    v = base + i * step + np.float32(3.0) * np.sin((i + seed) * np.float32(0.7))
+    v = v.astype(np.float32)
+    v[v == 0] = np.float32(0.5)
+    return v
+
+def seq_i32(n, base, step, seed=0):
+    i = np.arange(n, dtype=np.int64)
+    v = (base + i * step + ((i + seed) * 131 % 257) - 128).astype(np.int32)
+    return v
+
+def shifts_i32(n):
+    return (np.arange(n, dtype=np.int64) % 31).astype(np.int32)
+
+def f32_to_f16bits(a):
+    return a.astype(np.float16).view(np.uint16)
+
+# --------------------------------------------------------------------------
+# registry: case -> spec dict.
+#   fam: binary|scalar|unary|reduce|expand|matmul|convert
+#   op : numpy semantic key
+#   M,N[,K], dt_in, dt_out, scalar (for *S), axis/bcast (reduce/expand), eps
+# --------------------------------------------------------------------------
+F32 = 'f32'; I32 = 'i32'; F16 = 'f16'
+I16 = 'i16'; U32 = 'u32'; U16 = 'u16'; S8 = 's8'; U8 = 'u8'
+
+def R(**kw):
+    return kw
+
+REG = {}
+
+# ---- VEC binary (same dtype in/out) ----
+for name, op in [('tadd','add'),('tsub','sub'),('tmul','mul'),('tdiv','div'),
+                 ('tmax','max'),('tmin','min')]:
+    REG[name] = R(fam='binary', op=op, M=16, N=16, dt=F32, eps=1e-4)
+for name, op in [('tand','and'),('tor','or'),('txor','xor'),('trem','rem'),
+                 ('tshl','shl'),('tshr','shr')]:
+    REG[name] = R(fam='binary', op=op, M=16, N=16, dt=I32, eps=0)
+
+# ---- VEC unary ----
+for name, op in [('tabs','abs'),('tneg','neg'),('trelu','relu')]:
+    REG[name] = R(fam='unary', op=op, M=16, N=16, dt=F32, eps=1e-5)
+REG['tnot'] = R(fam='unary', op='not', M=16, N=16, dt=I32, eps=0)
+# reinterpret_tile: bitcast fp32->int32, clear sign bit (TANDS 0x7fffffff), then a
+# native fp32 op re-tags the backing; host reads back |x| as fp32. golden = abs.
+REG['reinterpret_tile'] = R(fam='unary', op='abs', M=16, N=16, dt=F32, eps=0)
+# reinterpret_tcmp: same bitcast but consumed by TCMP -> run-fail witness (emulator
+# TCMP handler rejects reinterpret-view sources). NO golden (crashes before store);
+# would be where(int_bits(a)>int_bits(b), tru, prior) once the model accepts views.
+# tcvt (f32->i32) left run-only: rounding mode (trunc vs RNE) not pinned by docs.
+REG['tfma'] = R(fam='ternary', op='fma', M=16, N=16, dt=F32, eps=1e-4)
+
+# ---- VEC scalar (*S) ----
+SCAL = np.float32(1.75)
+for name, op in [('tadds','add'),('tsubs','sub'),('tmuls','mul'),('tdivs','div'),
+                 ('tmaxs','max'),('tmins','min')]:
+    REG[name] = R(fam='scalar', op=op, M=16, N=16, dt=F32, scalar=float(SCAL), eps=1e-4)
+for name, op in [('tands','and'),('tors','or'),('txors','xor'),('trems','rem'),
+                 ('tshls','shl'),('tshrs','shr')]:
+    REG[name] = R(fam='scalar', op=op, M=16, N=16, dt=I32, scalar=5, eps=0)
+REG['texpands'] = R(fam='fill', op='fill', M=16, N=16, dt=F32, scalar=float(SCAL), eps=0)
+
+# ---- TCMP/TCMPS produce a packed predicate consumed by TSEL. End-to-end golden:
+#      out = where(a <cmp> b|s, tru, prior). tsel chains TCMP<LT> -> TSEL. ----
+REG['tsel']  = R(fam='cmpsel',   mode='lt', M=16, N=16, dt=I32, eps=0)
+REG['tcmp']  = R(fam='cmpsel',   mode='gt', M=16, N=16, dt=I32, eps=0)
+REG['tcmps'] = R(fam='cmpsel_s', mode='gt', M=16, N=16, dt=I32, scalar=0, eps=0)
+# ---- TSELS: masked select between a tile source and a scalar; out = where(a>b, src, SVAL) ----
+REG['tsels'] = R(fam='tsels', mode='gt', M=16, N=16, dt=I32, scalar=777, eps=0)
+
+# ---- SFU transcendental (elementwise; positive bounded domain so log/sqrt/
+#      recip/rsqrt stay in-domain and exp does not overflow). SFU is a hardware
+#      approximation, so tolerance is relative (calibrated per op, see check). ----
+REG['texp']   = R(fam='transcend', op='exp',   M=16, N=16, dt=F32, eps=1e-5)
+REG['tlog']   = R(fam='transcend', op='log',   M=16, N=16, dt=F32, eps=1e-5)
+REG['trecip'] = R(fam='transcend', op='recip', M=16, N=16, dt=F32, eps=1e-5)
+REG['tsqrt']  = R(fam='transcend', op='sqrt',  M=16, N=16, dt=F32, eps=1e-5)
+REG['trsqrt'] = R(fam='transcend', op='rsqrt', M=16, N=16, dt=F32, eps=1e-5)
+
+# ---- TQUANT / TDEQUANT (explicit float multiplier + integer zeroPoint) ----
+#   TQUANT (pto-spec normative, format-conversion/TQUANT.md): "compute x*multiplier
+#   + zero_point, then apply the selected rounding mode"; Sat=1 clamps to S8/U8.
+#   → q = clamp(round_RNE(src*mult) + zp, -128, 127). multiplier/zeroPoint are
+#   NORMATIVELY MANDATORY (omitted B.IOR defaults 1.0/0 only). golden pins real
+#   mult/zp; the emulator IGNORES them → this case is expected to land in
+#   PRECISION-FAIL, witnessing model gap gfrun-5 (NOT a golden regression).
+#   TDEQUANT: dst = (src - zp) * mult                         (fp32)
+REG['tquant']   = R(fam='quant',   M=8, N=256, mult=0.5, zp=1, eps=0)  # real mult/zp per spec
+REG['tdequant'] = R(fam='dequant', M=8, N=256, mult=2.0, zp=0, eps=0)
+
+# ---- TCVT (numeric conversion fp32 -> s32). Rounding mode pinned empirically
+#      below (round=...). Inputs span both signs with varied fractions so the
+#      chosen mode is actually exercised at the .5 boundary. ----
+# TCVT fp32->s32, default RMode=0: pto-spec format-conversion/TCVT.asl is normative
+# -- "RMode zero selects RTZ for floating-to-integer conversion and RNE for every
+# other conversion" (ASL returns NumericRound_RTZ). Demo TCVT(d,s) omits RMode ->
+# RMode=0 -> RTZ (truncate toward zero). Golden pins the SPEC (RTZ); model computes
+# RNE (verified: at -125.5 model=-126, spec RTZ=-125) -> precision-fail witness for
+# a model rounding bug. Prior 'rne' golden fit observed model behavior and MASKED
+# this gap -- corrected per golden-discipline (pin expected semantics, not observed).
+REG['tcvt'] = R(fam='cvt', M=16, N=16, din=F32, dout=I32, round='rtz', eps=0)
+
+# ---- TPART* : elementwise binary over the common valid region (full-valid here
+#      => plain elementwise). "PART" = partial-valid-region, not segmented. ----
+for name, op in [('tpartadd','add'),('tpartmul','mul'),('tpartmax','max'),('tpartmin','min')]:
+    REG[name] = R(fam='binary', op=op, M=16, N=16, dt=F32, eps=1e-4)
+
+# ---- SFU layout / sort (deterministic reorder; exact golden) ----
+REG['ttrans']  = R(fam='transpose', M=16, N=16, dt=F32, eps=0)
+REG['tconcat'] = R(fam='concat', M=16, N=8, dt=F32, eps=0)   # [MxN | MxN] -> Mx2N
+REG['tsort']   = R(fam='sort', M=32, N=32, dt=F32, eps=1e-6, desc=0)
+
+# ---- SFU reduce (row: reduce over cols -> per-row scalar at out[r*N+0];
+#                  col: reduce over rows -> per-col scalar at out[0*N+c]=out[c]) ----
+for name, op in [('trowsum','sum'),('trowmax','max'),('trowmin','min'),('trowprod','prod')]:
+    REG[name] = R(fam='reduce', op=op, foot='row', M=16, N=16, dt=F32, eps=1e-3)
+for name, op in [('tcolsum','sum'),('tcolmax','max'),('tcolmin','min'),('tcolprod','prod')]:
+    REG[name] = R(fam='reduce', op=op, foot='col', M=16, N=16, dt=F32, eps=1e-3)
+# boxed-col store witness: colReduce 直接输出 valid col(VN=40) < physical col(N=64), 直接 TSTORE 崩。
+# spec 预期语义(TCOLMAX.asl): dst valid=1×VN, out[0,j]=max_rows(src[:,j]) for j<VN; 物理 [VN:N] 为
+# Null padding(不校)。现为 run-fail witness(崩在 TSTORE 前无输出); 模型修好后 golden 自动校前 VN 列。
+REG['tcolmax_boxcol'] = R(fam='reduce', op='max', foot='col', M=16, N=64, VN=40, dt=F32, eps=1e-3)
+
+# ---- CUBE matmul family (f16 inputs, f32 accumulate; wide eps for f16 rounding) ----
+REG['tmatmul']        = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+REG['tmatmul_acc']    = R(fam='matmul', M=32, N=32, K=32, post='acc',  dt_out=F32, eps=2e-2)
+REG['tmatmul_bias']   = R(fam='matmul', M=32, N=32, K=32, post='bias', dt_out=F32, eps=2e-2)
+REG['tmatmul_relu']   = R(fam='matmul', M=32, N=32, K=32, post='relu', dt_out=F16, eps=3e-2)
+REG['tmatmul_rowmax'] = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+REG['tmatmul_f16']    = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F16, eps=3e-2)
+# TMATMUL_MX FP16 pair (no scales): identical math to a plain f16 matmul; the
+# convenience overload just omits the scale operand. Golden = A@B, same family.
+REG['tmatmul_mx']     = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+# TGEMV: D(1,N) = Vec(1,K) @ Mtx(K,N). GEMV is a matmul with M=1 (in_a=vec,
+# in_b=mtx). doc arg order TGEMV(Dst,Mtx,Vec) but math source A=Vec, B=Mtx.
+REG['tgemv']          = R(fam='matmul', M=1, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+
+# ---- FIXP convert (matmul then cast to fp16 via fixp::convert) ----
+REG['convert'] = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F16, eps=3e-2)
+
+# ---- FIXP B.FPATR matrix post-process (matmul + quant/activation/reduction) ----
+# Golden pins the *spec* post-process contract (pto-spec arch/profile/
+# matrix-postprocess.asl + matrix-quantization.asl). Shared FP19 carriers
+# (must match the demo make_*_quant constants exactly):
+#   FP19 16.0 = 0x20C00 ; 8.0 = 0x20800 ; 1.0 = 0x1FC00 ; 0.5 = 0x1F800.
+# S8 quant (QF322S8Pre / VQF322S8Pre): offset width 9 (S9 intermediate). Scale
+# folded into a single multiplier per spec MatrixSelectedMultiplier; positive ->
+# scale, negative under LReLU/PReLU -> slope. Then round+sat S9, +offset, encode.
+#
+# Tier 1 -- keep_acc reductions: main D published is the *plain* fp32 matmul
+# (RowMax/GroupMax/MaxAbs write only the *auxiliary* destinations, which these
+# demos do not store). So golden = matmul, post=none. Guards that enabling the
+# reduction path does not corrupt D.
+REG['rowmax_acc'] = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+REG['group_max']  = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+REG['chain']      = R(fam='matmul', M=32, N=32, K=32, post='none', dt_out=F32, eps=2e-2)
+# Tier 2 -- quantizing post-process: D itself is requantized.
+#   scale=16.0 (0x20C00) keeps D*scale in +-40 -> rich, non-saturating S8 spread.
+#   offset=5 exercises the S9 offset path. itol=1 absorbs f16-matmul boundary
+#   rounding (host f32 accum vs cube accum) without masking a scale/offset bug.
+REG['s8_scalar']      = R(fam='mquant', M=32, N=32, K=32, qmode='s8', fp19=0x20C00, off=5, dt_out=S8, itol=1)
+REG['scalar_generic'] = R(fam='mquant', M=32, N=32, K=32, qmode='s8', fp19=0x20C00, off=5, dt_out=S8, itol=1)
+REG['s8_vector']      = R(fam='mquant', M=32, N=32, K=32, qmode='s8', fp19=0x20C00, off=5, dt_out=S8, itol=1)
+REG['vquant_f16']     = R(fam='mquant', M=32, N=32, K=32, qmode='f16', fp19=0x20C00, off=0, dt_out=F16, eps=3e-2)
+# Tier 3 -- activation fused with the multiplier. lrelu: pos*scale, neg*slope,
+# then S8 quant. prelu: fixp::f16() convert (scale=1.0), pos*1, neg*slope, fp16.
+REG['lrelu'] = R(fam='mquant', M=32, N=32, K=32, qmode='s8',  fp19=0x20C00, off=5,
+                 relu='lrelu', slope_fp19=0x20800, dt_out=S8, itol=1)
+REG['prelu'] = R(fam='mquant', M=32, N=32, K=32, qmode='f16', fp19=0x1FC00, off=0,
+                 relu='prelu', slope_fp19=0x1F800, dt_out=F16, eps=3e-2)
+# cscale: TMATMUL_ACC with per-row U8 exponent on the initial accumulator C
+# (pto-spec cube.asl MatrixInitialAccumulatorValue -> C/2^exp), then A@B on top.
+# exp=1 (all rows) -> d = A@B + C/2.
+REG['cscale'] = R(fam='cscale', M=32, N=32, K=32, cexp=1, dt_out=F32, eps=2e-2)
+
+# ---- PTO 0.58.5 layout ops (SFU/TEPL, U32 CUBE) ----
+# TPACK / TUNPACK operate on *logical* U32 elements (pto-spec rearrangement.asl
+# TileReadLogicalElement), so the CUBE_M16/M32 physical layout is transparent and
+# the golden is plain row-major element-wise.
+#   TPACK  (rearrangement.asl:296): dst = (src0 & mask(w0)) | ((src1 & mask(w1)) << 8*w0)
+#     control[7:0]=src0 field width (bytes), control[15:8]=src1 width; 1..3 each, sum<=4.
+#   TUNPACK(rearrangement.asl:332): dst = (src >> 8*off) & mask(cnt) ; control[7:0]=off(0..3),
+#     control[15:8]=cnt(1..4), off+cnt<=4. Zero-extended raw byte extraction.
+REG['tpack']   = R(fam='tpack',   M=32, N=32, w0=2, w1=2, eps=0)
+REG['tunpack'] = R(fam='tunpack', M=32, N=32, off=1, cnt=2, eps=0)
+# TPERMUTE / TSHUF read *physical* cell bytes/words (rearrangement.asl:177/222), so a
+# full permute/shuffle golden would need the CUBE fractal layout model. Instead we
+# guard the *identity* config, which is layout-invariant and verifiable:
+#   TPERMUTE: index byte j = j mod row_bytes (M32 row_bytes=4) -> each dst byte reads
+#     src0's own byte within its word -> dst == src0 (words map wholesale).
+#   TSHUF:    mode=UP(0), controls all 0 (b=0) -> candidate_row == row -> dst == src.
+# (Full non-identity golden deferred until the physical layout is modelled.)
+REG['tpermute'] = R(fam='eqsrc', M=32, N=32, dt=U32, mk='permute', eps=0)
+REG['tshuf']    = R(fam='eqsrc', M=32, N=32, dt=U32, mk='shuf', eps=0)
+# TGPR2T has no pto-spec ASL (spec still v0.58.4). Doc-derived sanity golden only:
+# all-zero predicate planes -> all-zero U8 output (zero-in -> zero-out repack).
+REG['tgpr2t']   = R(fam='zeros', M=32, N=4, dt=U8, eps=0)
+
+# ---- TCI (create index / "vci"): self-generated iota, NO input ----
+#   ascending col k = start+k, descending = start-k; ValidRow=1 (TCI.md).
+REG['tci']      = R(fam='iota', M=1, N=64, dt=I32, start=0,   desc=0, vc=64, eps=0)
+REG['tci_desc'] = R(fam='iota', M=1, N=64, dt=I32, start=100, desc=1, vc=64, eps=0)
+REG['tci_s16']  = R(fam='iota', M=1, N=64, dt=I16, start=0,   desc=0, vc=64, eps=0)
+REG['tci_u32']  = R(fam='iota', M=1, N=64, dt=U32, start=0,   desc=0, vc=64, eps=0)
+REG['tci_u16']  = R(fam='iota', M=1, N=64, dt=U16, start=0,   desc=0, vc=64, eps=0)
+
+# ---- MGATHER / MSCATTER / MGATHER_MASK (GM byte-offset addressing) ----
+REG['mgather']      = R(fam='gather',      BM=8, BN=1024, OM=8, ON=32, eps=0)
+REG['mscatter']     = R(fam='scatter',     BM=8, BN=1024, OM=8, ON=32, eps=0)
+REG['mgather_mask'] = R(fam='gather_mask', BM=8, BN=1024, OM=8, ON=32, eps=0)
+REG['mscatter_mask'] = R(fam='scatter_mask', BM=8, BN=1024, OM=8, ON=32, eps=0)
+# MGATHER_CAS: per-element compare-and-swap on GM. observedOld[i]=*(base+off[i])
+# (always the pre-swap value); if *(base+off[i])==expected[i] then it is set to
+# replacement[i], else unchanged. Injective offsets; ~half lanes hit / half miss.
+# Golden checks BOTH observedOld (out.bin) and the post-CAS backing (out_mem.bin).
+REG['mgather_cas']  = R(fam='cas', BM=8, BN=1024, OM=8, ON=32, eps=0)
+
+# ---- expand-arith: fused broadcast + binary op. row broadcasts a per-row scalar
+#      (src1[i,0], M x 1 source); col broadcasts a per-col scalar (src1[0,j],
+#      1 x N source). EXPDIF = exp(src0-src1) (base-e, softmax). Semantics from
+#      docs/intrinsics/t{row,col}expand{op}.md. Positive bounded inputs so div
+#      has nonzero divisor and expdif's exp(a-b) stays in fp32 range. ----
+for op in ['add', 'sub', 'mul', 'div', 'max', 'min', 'expdif']:
+    REG['trowexpand' + op] = R(fam='expandarith', op=op, foot='row', M=16, N=16, eps=1e-5)
+    REG['tcolexpand' + op] = R(fam='expandarith', op=op, foot='col', M=16, N=16, eps=1e-5)
+
+# TROWEXPAND/TCOLEXPAND (copy-expand). Authoritative semantics (pto-spec normative
+# ASL): TROWEXPAND "broadcasts one one-column source bit-for-bit across every valid
+# destination column" -> dst[r,c]=src[r,0]; TCOLEXPAND broadcasts a one-row source
+# across every valid row -> dst[r,c]=src[0,c]. golden pins the full M x N broadcast.
+# The emulator pins the fill extent to the source valid dim (=1), a degenerate
+# expand, so these are expected to land in PRECISION-FAIL, witnessing that model
+# contract gap (header/impl vs spec). foot=row: src is an M-vector column; foot=col:
+# src is an M x N tile whose valid row 0 holds the N-vector.
+REG['trowexpand'] = R(fam='copyexpand', foot='row', M=16, N=16, eps=0)
+REG['tcolexpand'] = R(fam='copyexpand', foot='col', M=16, N=16, eps=0)
+
+# ---- TROW/TCOL ARGMAX/ARGMIN: index output forced to UINT32; reduce shape ----
+#   src distinct per line (perm) so the arg index is unambiguous.
+REG['trowargmax'] = R(fam='argreduce', op='max', foot='row', M=16, N=16, eps=0)
+REG['trowargmin'] = R(fam='argreduce', op='min', foot='row', M=16, N=16, eps=0)
+REG['tcolargmax'] = R(fam='argreduce', op='max', foot='col', M=16, N=16, eps=0)
+REG['tcolargmin'] = R(fam='argreduce', op='min', foot='col', M=16, N=16, eps=0)
+
+# ---- TEXTRACT / TINSERT (sub-tile copy at (indexRow,indexCol)) ----
+# Authoritative semantics (pto-spec normative ASL): TINSERT "inserts a source Tile
+# into a snapshotted OLD destination at encoded row/column offsets" — source0 is the
+# persistent old destination (base PRESERVED outside the window), source1 the patch.
+# -> dst = base.copy(); dst[OR:OR+SM, OC:OC+SN] = patch. golden pins that. The
+# emulator writes a fresh tile with only a partial window and does not preserve base,
+# so TINSERT is expected to land in PRECISION-FAIL (model contract gap). TEXTRACT
+# stays run-fail (gfrun descriptor contract rejects it); its golden (check_extract)
+# is kept READY so it auto-validates once the model implements the extract path.
+REG['tinsert'] = R(fam='insert', DM=16, DN=32, SM=8, SN=16, OR=4, OC=8, eps=0)
+# TEXTRACT (pto-spec normative ASL): dst[j,i] = src[OR+j, OC+i] (copy the rectangle
+# beginning at the encoded row/col offset). READY golden — the case currently
+# run-fails (gfrun descriptor contract), so it stays run-fail until the model
+# implements the extract path, then check_extract auto-validates.
+REG['textract'] = R(fam='extract', SM=16, SN=32, DM=8, DN=16, OR=4, OC=8, eps=0)
+
+# ---- TMRGSORT / TGATHER / TSCATTER (irregular-and-complex). READY goldens: all
+#      three currently run-fail (model stubs/gaps); goldens encode the pto-spec
+#      normative semantics and auto-validate once the model implements them. ----
+#   TMRGSORT: stably merge two sorted single-row streams -> sorted(concat).
+#   TGATHER : dst[r,c] = value[idx[r,c], c]  (row-index gather, per column).
+#   TSCATTER: dst[idx[r,c], c] = src[r,c]     (row-index scatter; idx injective/col).
+REG['tmrgsort'] = R(fam='mrgsort', H=128, W=256, eps=0)
+REG['tgather']  = R(fam='tgather', M=16, N=16, eps=0)
+REG['tscatter'] = R(fam='tscatter', M=16, N=16, eps=0)
+
+# ---- TFILLPAD (layout/init): copy the VALID source rectangle into dst and fill
+#   the physical padding with zero. Authoritative semantics: TFILLPAD.md ("复制
+#   有效源区域, 并将绑定标量写入 padding") + the page's worked example (InputTile
+#   valid 9x9 inside a 16x16 physical, OutputTile PadValue::Zero); cpu_sim
+#   TFillPad.hpp static_assert PadVal==Zero confirms zero-pad only. src is a
+#   VR x VC valid region in a physical M x N tile -> dst[i,j] = src[i,j] for
+#   i<VR & j<VC, else 0.
+REG['tfillpad'] = R(fam='fillpad', M=16, N=16, VR=9, VC=9, eps=0)
+
+# ---- range::Assemble: a destination-side range carrier layered over TLOAD. The
+#   carrier only retargets the load; the data is an identity copy of the source
+#   GM tile -> out == in. golden = identity (transitive TLOAD coverage made
+#   explicit with a numeric check).
+REG['range_assemble'] = R(fam='identity', M=4, N=8, dt=F32, eps=0)
+
+# ---- region TileArray + TASSEMBLY: NF row-major fragments (PM x FN) laid out
+#   block-major in memory are column-concatenated into a PM x (NF*FN) parent
+#   (TileArrayRegionAsm.cpp assembles 4 x 32x16 -> 32x64). golden = concat over
+#   columns. The case currently run-fails (region producer path not yet
+#   implemented in the model); the golden is READY and auto-validates once it is.
+REG['region_tilearray'] = R(fam='regionasm', PM=32, PN=64, FN=16, NF=4, eps=0)
+
+# ---- TTRI: self-generated triangular matrix (no input). pto-spec normative ASL
+#   (TTRI.asl): the 1-arg C++ overload omits B.IOR -> diagonal 0 + LOWER
+#   orientation; logical element [r,c] is typed 1.0 iff c <= r+diagonal (here
+#   c <= r), else 0.0 (exact FP32 0/1 encodings). golden = tril(ones).
+REG['ttri'] = R(fam='ttri', M=16, N=16, diag=0, upper=0, eps=0)
+
+# --------------------------------------------------------------------------
+NP = {F32: np.float32, I32: np.int32, F16: np.float16,
+      I16: np.int16, U32: np.uint32, U16: np.uint16, S8: np.int8, U8: np.uint8}
+
+def np_read(path, dt):
+    return np.fromfile(path, dtype=NP[dt])
+
+def gen(case, chkdir):
+    s = REG[case]; fam = s['fam']; op = s.get('op', '')
+    os.makedirs(chkdir, exist_ok=True)
+    # --- TCI: self-generated iota, no input files ---
+    if fam == 'iota':
+        return
+    # --- transcendental: positive bounded input in [0.5, 8.0] (log/sqrt/recip/
+    #     rsqrt domain-safe; exp(8)=2981 stays in fp32 range). ---
+    if fam == 'transcend':
+        n = s['M'] * s['N']
+        i = np.arange(n, dtype=np.float32)
+        a = (np.float32(0.5) + np.float32(7.5) * (np.float32(0.5) *
+             (np.float32(1.0) + np.sin(i * np.float32(0.37))))).astype(np.float32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- MGATHER / MSCATTER / MGATHER_MASK: host owns base + byte offsets ---
+    if fam in ('gather', 'scatter', 'gather_mask', 'scatter_mask'):
+        BNE = s['BM'] * s['BN']; ONE = s['OM'] * s['ON']
+        base = (np.arange(BNE, dtype=np.float32) * np.float32(0.5) + np.float32(1.0))
+        idx = ((np.arange(ONE, dtype=np.int64) * 101 + 7) % BNE)   # injective (101 coprime 8192)
+        off = (idx * 4).astype(np.uint32)                          # U32 byte displacement
+        base.tofile(os.path.join(chkdir, 'in_base.bin'))
+        off.tofile(os.path.join(chkdir, 'in_off.bin'))
+        if fam in ('scatter', 'scatter_mask'):
+            src = -(np.arange(ONE, dtype=np.float32) + np.float32(1.0))   # distinct from base
+            src.tofile(os.path.join(chkdir, 'in_src.bin'))
+        if fam in ('gather_mask', 'scatter_mask'):
+            mask = ((np.arange(ONE, dtype=np.int64) % 3) != 0).astype(np.uint8)
+            mask.tofile(os.path.join(chkdir, 'in_mask.bin'))
+        return
+    # --- MGATHER_CAS: host owns backing + byte offsets + expected + replacement.
+    #     expected is set so even lanes HIT (== current slot) and odd lanes MISS. ---
+    if fam == 'cas':
+        BNE = s['BM'] * s['BN']; ONE = s['OM'] * s['ON']
+        base = (np.arange(BNE, dtype=np.float32) * np.float32(0.5) + np.float32(1.0))
+        idx = ((np.arange(ONE, dtype=np.int64) * 101 + 7) % BNE)   # injective
+        off = (idx * 4).astype(np.uint32)
+        cur = base[idx]                                            # current slot values
+        rep = -(np.arange(ONE, dtype=np.float32) + np.float32(1.0))  # distinct replacements
+        exp = cur.copy()                                           # even lanes: exact match -> HIT
+        miss = (np.arange(ONE) % 2) == 1
+        exp[miss] = cur[miss] + np.float32(1000.0)                 # odd lanes: mismatch -> MISS
+        base.tofile(os.path.join(chkdir, 'in_base.bin'))
+        off.tofile(os.path.join(chkdir, 'in_off.bin'))
+        exp.astype(np.float32).tofile(os.path.join(chkdir, 'in_exp.bin'))
+        rep.astype(np.float32).tofile(os.path.join(chkdir, 'in_rep.bin'))
+        return
+    # --- TCMP/TCMPS end-to-end: compare operands + prior + true ---
+    if fam in ('cmpsel', 'cmpsel_s'):
+        n = s['M'] * s['N']
+        a = seq_i32(n, 1, 2, 0)
+        prior = seq_i32(n, -1, -1, 4)
+        tru = seq_i32(n, 100, 3, 9)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        if fam == 'cmpsel':
+            b = seq_i32(n, 3, 1, 9)                # tile-tile compare operand
+            b.tofile(os.path.join(chkdir, 'in_b.bin'))
+            prior.tofile(os.path.join(chkdir, 'in_c.bin'))
+            tru.tofile(os.path.join(chkdir, 'in_d.bin'))
+        else:                                       # tile-scalar
+            prior.tofile(os.path.join(chkdir, 'in_b.bin'))
+            tru.tofile(os.path.join(chkdir, 'in_c.bin'))
+        return
+    # --- quant: fp32 source spanning +-256 so round+zp saturates at S8 edges ---
+    if fam == 'quant':
+        M, N = s['M'], s['N']
+        n = M * N
+        i = np.arange(n, dtype=np.float32)
+        a = (np.float32(512.0) * (i / np.float32(n)) - np.float32(256.0) +
+             np.float32(0.5) * np.sin(i * np.float32(0.9))).astype(np.float32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- cvt: fp32 source with varied fractional parts, both signs; includes
+    #     exact .5 midpoints so the rounding mode is exercised. ---
+    if fam == 'cvt':
+        M, N = s['M'], s['N']
+        n = M * N
+        i = np.arange(n, dtype=np.float32)
+        # base ramp across [-N/2, +N/2) plus a fractional wobble hitting .5/.25/.75
+        base = (i - np.float32(n // 2)).astype(np.float32)
+        frac = (np.float32(0.5) * ((i.astype(np.int64) % 4).astype(np.float32) - 1.0))  # {-0.5,0,0.5,1.0}
+        a = (base + frac).astype(np.float32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- dequant: int8 source spanning full [-128,127] ---
+    if fam == 'dequant':
+        M, N = s['M'], s['N']
+        n = M * N
+        a = (((np.arange(n, dtype=np.int64) * 63) % 256) - 128).astype(np.int8)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- transpose: single MxN source ---
+    if fam == 'transpose':
+        M, N = s['M'], s['N']
+        a = seq_f32(M * N, 1.0, 0.1, 5)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- concat: two MxN sources (distinct ranges) ---
+    if fam == 'concat':
+        M, N = s['M'], s['N']
+        a = seq_f32(M * N, 1.0, 0.1, 1)
+        b = seq_f32(M * N, 100.0, 0.1, 2)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        b.tofile(os.path.join(chkdir, 'in_b.bin'))
+        return
+    # --- sort: per-row distinct values (a per-row permutation so ordering is
+    #     unambiguous); host owns the MxN source. ---
+    if fam == 'sort':
+        M, N = s['M'], s['N']
+        r = np.arange(M)[:, None]; c = np.arange(N)[None, :]
+        # distinct within a row and shuffled: value = ((5*c+r) % N) + r*N, float.
+        a = (((5 * c + r) % N) + r * N).astype(np.float32)
+        a.reshape(-1).tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- expand-arith: src0 MxN + broadcast src1. row: src1 is M per-row scalars;
+    #     col: src1 is a full MxN whose row 0 holds the N per-col scalars. Inputs
+    #     positive-bounded [0.5,4.5] (div divisor nonzero; expdif exp(a-b) safe). ---
+    if fam == 'expandarith':
+        M, N = s['M'], s['N']
+        ii = np.arange(M * N, dtype=np.float32)
+        a = (np.float32(0.5) + np.float32(2.0) *
+             (np.float32(1.0) + np.sin(ii * np.float32(0.29)))).astype(np.float32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        if s['foot'] == 'row':
+            jj = np.arange(M, dtype=np.float32)
+            b = (np.float32(0.5) + np.float32(2.0) *
+                 (np.float32(1.0) + np.cos(jj * np.float32(0.41)))).astype(np.float32)
+        else:
+            jj = np.arange(N, dtype=np.float32)
+            b = (np.float32(0.5) + np.float32(2.0) *
+                 (np.float32(1.0) + np.cos(jj * np.float32(0.41)))).astype(np.float32)  # GENUINE 1 x N
+        b.tofile(os.path.join(chkdir, 'in_b.bin'))
+        return
+    # --- copy-expand: match the demo's source read. row: demo loads an M x 1
+    #     column (M floats) -> dst[r,c]=src[r]. col: demo loads an M x N tile whose
+    #     valid row 0 is the N-vector -> dst[r,c]=src[c]. Nonzero values so the
+    #     demo's `if(src[i]==0)` fallback is a no-op under RES_CHECK. ---
+    if fam == 'copyexpand':
+        M, N = s['M'], s['N']
+        if s['foot'] == 'row':
+            col = ((np.arange(M, dtype=np.float32) + np.float32(1.0)) * np.float32(0.5))
+            col.tofile(os.path.join(chkdir, 'in_a.bin'))
+        else:
+            row0 = ((np.arange(N, dtype=np.float32) + np.float32(1.0)) * np.float32(0.25))
+            row0.astype(np.float32).tofile(os.path.join(chkdir, 'in_a.bin'))   # GENUINE 1 x N
+        return
+    # --- ARGMAX/ARGMIN: src distinct per row & per col (double perm) ---
+    if fam == 'argreduce':
+        M, N = s['M'], s['N']
+        r = np.arange(M)[:, None]; c = np.arange(N)[None, :]
+        # (7*c + 3*r) % N is a per-row permutation (7 coprime 16); add r to also
+        # separate columns so per-col reductions have a unique arg too.
+        a = ((7 * c + 3 * r) % N + r * N).astype(np.float32)
+        a.reshape(-1).tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- TSELS: compare operands (a,b) + tile source ---
+    if fam == 'tsels':
+        n = s['M'] * s['N']
+        a = seq_i32(n, 1, 2, 0)
+        b = seq_i32(n, 3, 1, 9)
+        src = seq_i32(n, 100, 3, 5)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        b.tofile(os.path.join(chkdir, 'in_b.bin'))
+        src.tofile(os.path.join(chkdir, 'in_c.bin'))
+        return
+    # --- TEXTRACT: host owns the big src tile ---
+    if fam == 'extract':
+        SNE = s['SM'] * s['SN']
+        src = seq_f32(SNE, 1.0, 0.1, 3)
+        src.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- TINSERT: host owns base + patch ---
+    if fam == 'insert':
+        DNE = s['DM'] * s['DN']; SNE = s['SM'] * s['SN']
+        base = seq_f32(DNE, 1.0, 0.1, 3)
+        patch = -(seq_f32(SNE, 2.0, 0.07, 9))
+        base.tofile(os.path.join(chkdir, 'in_a.bin'))
+        patch.tofile(os.path.join(chkdir, 'in_b.bin'))
+        return
+    # --- TMRGSORT: two ascending-sorted single-row streams (disjoint interleave) ---
+    if fam == 'mrgsort':
+        H = s['H']
+        a = (2.0 * np.arange(H, dtype=np.float32))          # 0,2,4,... sorted
+        b = (2.0 * np.arange(H, dtype=np.float32) + 1.0)    # 1,3,5,... sorted, disjoint
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        b.tofile(os.path.join(chkdir, 'in_b.bin'))
+        return
+    # --- TGATHER: value MxN + per-coordinate ROW index in [0,M) (nontrivial) ---
+    if fam == 'tgather':
+        M, N = s['M'], s['N']
+        r = np.arange(M)[:, None]; c = np.arange(N)[None, :]
+        val = ((np.arange(M * N, dtype=np.float32) + 1.0) * np.float32(0.1))
+        idx = ((7 * r + 3 * c) % M).astype(np.int32)        # picks a row per (r,c)
+        val.tofile(os.path.join(chkdir, 'in_a.bin'))
+        idx.reshape(-1).tofile(os.path.join(chkdir, 'in_idx.bin'))
+        return
+    # --- TSCATTER: src MxN + per-column PERMUTATION row index (injective/col) ---
+    if fam == 'tscatter':
+        M, N = s['M'], s['N']
+        r = np.arange(M)[:, None]; c = np.arange(N)[None, :]
+        src = ((np.arange(M * N, dtype=np.float32) + 1.0) * np.float32(0.1))
+        idx = ((r + c) % M).astype(np.int32)                # each column is a perm of [0,M)
+        src.tofile(os.path.join(chkdir, 'in_a.bin'))
+        idx.reshape(-1).tofile(os.path.join(chkdir, 'in_idx.bin'))
+        return
+    # --- TFILLPAD: full physical M x N nonzero source (golden reads only the
+    #     VR x VC valid rectangle; the rest is what the op must zero out). ---
+    if fam == 'fillpad':
+        M, N = s['M'], s['N']
+        a = seq_f32(M * N, 1.0, 0.13, 3)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- region TileArray: NF contiguous PM x FN blocks, each block distinct so
+    #     a mis-ordered assembly is caught. ---
+    if fam == 'regionasm':
+        PM, PN = s['PM'], s['PN']
+        a = seq_f32(PM * PN, 1.0, 0.05, 7)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    # --- TTRI: self-generated, no input files ---
+    if fam == 'ttri':
+        return
+    # --- cscale: matmul + fp32 accumulator C (scaled per-row) ---
+    if fam == 'cscale':
+        M, N, K = s['M'], s['N'], s['K']
+        ii = np.arange(M * K, dtype=np.float32)
+        jj = np.arange(K * N, dtype=np.float32)
+        A = (np.sin(ii * np.float32(0.13)) * np.float32(0.8)).astype(np.float16)
+        B = (np.cos(jj * np.float32(0.21)) * np.float32(0.8)).astype(np.float16)
+        kk = np.arange(M * N, dtype=np.float32)
+        C = (np.sin(kk * np.float32(0.07)) * np.float32(0.5)).astype(np.float32)
+        A.tofile(os.path.join(chkdir, 'in_a.bin'))
+        B.tofile(os.path.join(chkdir, 'in_b.bin'))
+        C.tofile(os.path.join(chkdir, 'in_c.bin'))
+        return
+    # --- PTO 0.58.5 layout ops: U32 inputs (full 32-bit spread so byte fields matter) ---
+    if fam in ('tpack', 'tunpack'):
+        M, N = s['M'], s['N']; n = M * N
+        i = np.arange(n, dtype=np.uint64)
+        a = ((i * np.uint64(2654435761) + np.uint64(0x9E3779B1)) & np.uint64(0xFFFFFFFF)).astype(np.uint32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        if fam == 'tpack':
+            b = ((i * np.uint64(40503) + np.uint64(0x1234ABCD)) & np.uint64(0xFFFFFFFF)).astype(np.uint32)
+            b.tofile(os.path.join(chkdir, 'in_b.bin'))
+        return
+    # --- TPERMUTE/TSHUF identity config (golden = known source) ---
+    if fam == 'eqsrc':
+        M, N = s['M'], s['N']; n = M * N
+        i = np.arange(n, dtype=np.uint64)
+        a = ((i * np.uint64(2654435761) + np.uint64(0x9E3779B1)) & np.uint64(0xFFFFFFFF)).astype(np.uint32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))     # src0 / src
+        if s['mk'] == 'permute':
+            b = ((i * np.uint64(40503) + np.uint64(0x1234ABCD)) & np.uint64(0xFFFFFFFF)).astype(np.uint32)
+            b.tofile(os.path.join(chkdir, 'in_b.bin'))  # src1 (unused by identity golden)
+            idx = (np.arange(n * 4, dtype=np.uint8) % 4)  # byte j -> j mod 4 (identity to src0)
+            idx.tofile(os.path.join(chkdir, 'in_idx.bin'))
+        else:  # shuf: control tile all zero -> row identity
+            np.zeros(n, dtype=np.uint32).tofile(os.path.join(chkdir, 'in_ctrl.bin'))
+        return
+    # --- TGPR2T sanity: zero planes -> zero output (no input files) ---
+    if fam == 'zeros':
+        return
+    # --- matmul + fixp post-process families (f16 A/B, optional f32 C / bias) ---
+    if fam in ('matmul', 'mquant'):
+        M, N, K = s['M'], s['N'], s['K']
+        ii = np.arange(M * K, dtype=np.float32)
+        jj = np.arange(K * N, dtype=np.float32)
+        A = (np.sin(ii * np.float32(0.13)) * np.float32(0.8)).astype(np.float16)
+        B = (np.cos(jj * np.float32(0.21)) * np.float32(0.8)).astype(np.float16)
+        A.tofile(os.path.join(chkdir, 'in_a.bin'))
+        B.tofile(os.path.join(chkdir, 'in_b.bin'))
+        if s.get('post') == 'acc':
+            kk = np.arange(M * N, dtype=np.float32)
+            C = (np.sin(kk * np.float32(0.07)) * np.float32(0.5)).astype(np.float32)
+            C.tofile(os.path.join(chkdir, 'in_c.bin'))
+        if s.get('post') == 'bias':
+            bias = (np.arange(N, dtype=np.float32) * np.float32(0.01) + np.float32(0.5)).astype(np.float32)
+            bias.tofile(os.path.join(chkdir, 'in_bias.bin'))
+        return
+    # --- elementwise / reduce families ---
+    n = s['M'] * s['N']; dt = s['dt']
+    # --- src0 (in_a) ---
+    if fam == 'reduce':
+        # bounded positive near 1 so prod stays finite / well-conditioned
+        i = np.arange(n, dtype=np.float32)
+        a = (np.float32(1.0) + np.float32(0.3) * np.sin(i * np.float32(0.6))).astype(np.float32)
+        a.tofile(os.path.join(chkdir, 'in_a.bin'))
+        return
+    if dt == I32:
+        if op in ('shl', 'shr'):
+            # positive & bounded so logical==arithmetic shift and no overflow
+            a = (np.abs(seq_i32(n, 1, 3, 0)) & 0x000FFFFF).astype(np.int32)
+        elif op == 'rem':
+            a = (np.abs(seq_i32(n, 5, 2, 0)) & 0x0000FFFF).astype(np.int32)
+        else:
+            a = seq_i32(n, 1, 2, 0)
+    else:
+        a = seq_f32(n, 1.0, 0.1, 0)
+    a.tofile(os.path.join(chkdir, 'in_a.bin'))
+    # --- src1 (in_b) for binary/ternary ---
+    if fam in ('binary', 'ternary'):
+        if dt == I32:
+            if op in ('shl', 'shr'):
+                b = shifts_i32(n)                       # 0..30
+            elif op == 'rem':
+                b = (np.abs(seq_i32(n, 0, 1, 5)) % 17 + 1).astype(np.int32)  # 1..17
+            else:
+                b = seq_i32(n, 3, 1, 9)
+        else:
+            b = seq_f32(n, 2.0, 0.07, 9)
+            if op == 'div':
+                b[np.abs(b) < 0.5] = np.float32(0.9)    # avoid /0
+        b.tofile(os.path.join(chkdir, 'in_b.bin'))
+    if fam == 'ternary':
+        c = seq_f32(n, 0.5, 0.05, 21)
+        c.tofile(os.path.join(chkdir, 'in_c.bin'))
+
+def _elt(op, a, b=None, s=None):
+    if op == 'add': return a + (b if b is not None else s)
+    if op == 'sub': return a - (b if b is not None else s)
+    if op == 'mul': return a * (b if b is not None else s)
+    if op == 'div': return a / (b if b is not None else s)
+    if op == 'max': return np.maximum(a, b if b is not None else s)
+    if op == 'min': return np.minimum(a, b if b is not None else s)
+    if op == 'and': return a & (b if b is not None else np.int32(s))
+    if op == 'or':  return a | (b if b is not None else np.int32(s))
+    if op == 'xor': return a ^ (b if b is not None else np.int32(s))
+    if op == 'rem': return np.remainder(a, b if b is not None else np.int32(s))
+    if op == 'shl': return (a.astype(np.int32) << (b if b is not None else np.int32(s))).astype(np.int32)
+    if op == 'shr': return (a.astype(np.int32) >> (b if b is not None else np.int32(s))).astype(np.int32)
+    raise KeyError(op)
+
+def ref(case, chkdir):
+    s = REG[case]; dt = s['dt']; fam = s['fam']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), dt)
+    if fam == 'binary':
+        b = np_read(os.path.join(chkdir, 'in_b.bin'), dt)
+        return _elt(s['op'], a, b=b), dt
+    if fam == 'scalar':
+        return _elt(s['op'], a, s=s['scalar']), dt
+    if fam == 'ternary':  # fma = a*b + c
+        b = np_read(os.path.join(chkdir, 'in_b.bin'), dt)
+        c = np_read(os.path.join(chkdir, 'in_c.bin'), dt)
+        return a * b + c, dt
+    if fam == 'fill':
+        return np.full(a.shape, s['scalar'], dtype=np.float32), dt
+    if fam == 'identity':
+        return a, dt
+    if fam == 'unary':
+        op = s['op']
+        if op == 'abs':  return np.abs(a), dt
+        if op == 'neg':  return -a, dt
+        if op == 'relu': return np.maximum(a, np.float32(0)), dt
+        if op == 'not':  return ~a, dt
+        if op == 'cvt_f32_i32': return a.astype(np.int32), s.get('dt_out', I32)
+    raise KeyError(fam)
+
+def check_reduce(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    fn = {'sum': np.sum, 'max': np.max, 'min': np.min, 'prod': np.prod}[s['op']]
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    o = np_read(out_path, F32)
+    if s['foot'] == 'row':
+        red = fn(a, axis=1)                       # length M
+        got = o[:M]                               # genuine M x 1 dst (ops-20260904)
+    else:
+        vn = s.get('VN', N)                       # boxed col: valid col(VN) < physical col(N)
+        red = fn(a[:, :vn], axis=0)               # length VN (仅有效列; TCOLMAX 归约 valid 区)
+        got = o[:vn]                              # 校前 VN 列; 物理 padding [VN:N] 为 Null(不校)
+    eps = np.float32(s.get('eps', 1e-3))
+    atol = eps + eps * np.abs(red.astype(np.float32))
+    bad = np.flatnonzero(np.abs(got.astype(np.float32) - red.astype(np.float32)) > atol)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] REDUCE MISMATCH {bad.size}/{red.size} first@{i} got={got[i]} ref={red[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_matmul(case, chkdir):
+    s = REG[case]; M, N, K = s['M'], s['N'], s['K']
+    A = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.float16).reshape(M, K).astype(np.float32)
+    B = np.fromfile(os.path.join(chkdir, 'in_b.bin'), np.float16).reshape(K, N).astype(np.float32)
+    D = A @ B
+    post = s['post']
+    if post == 'acc':
+        D = D + np.fromfile(os.path.join(chkdir, 'in_c.bin'), np.float32).reshape(M, N)
+    elif post == 'bias':
+        D = D + np.fromfile(os.path.join(chkdir, 'in_bias.bin'), np.float32).reshape(1, N)
+    elif post == 'relu':
+        D = np.maximum(D, np.float32(0))
+    out_dt = s['dt_out']
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    ref_f = D.astype(NP[out_dt]).astype(np.float32).reshape(-1)
+    got = np.fromfile(out_path, NP[out_dt]).astype(np.float32).reshape(-1)[:ref_f.size]
+    eps = np.float32(s.get('eps', 2e-2))
+    atol = eps + eps * np.abs(ref_f)
+    bad = np.flatnonzero(np.abs(got - ref_f) > atol)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] MATMUL MISMATCH {bad.size}/{ref_f.size} first@{i} got={got[i]} ref={ref_f[i]}',
+          file=sys.stderr)
+    return 1
+
+def fp19_to_f32(v):
+    """Decode a 19-bit FP19 carrier (pto-spec arch/data-types/fp19.asl):
+    1 sign [18], 8-bit bias-127 exponent [17:10], 10-bit fraction [9:0]."""
+    v &= 0x7ffff
+    sign = (v >> 18) & 1
+    exp = (v >> 10) & 0xff
+    frac = v & 0x3ff
+    if exp == 0:
+        mag = float(frac) * (2.0 ** -136)      # subnormal (unused for our normals)
+    else:
+        mag = (1.0 + frac / 1024.0) * (2.0 ** (exp - 127))
+    return -mag if sign else mag
+
+def check_mquant(case, chkdir):
+    """B.FPATR matrix post-process golden (pto-spec matrix-postprocess.asl).
+    D = A@B (fp32); a single multiplier folds scale+activation:
+      positive -> scale ; negative under LReLU/PReLU -> slope (replaces scale).
+    S8 path: round+sat S9 intermediate, +offset, encode S8 (RNE).
+    F16 path: (D*mult) encoded to fp16 (RNE)."""
+    s = REG[case]; M, N, K = s['M'], s['N'], s['K']
+    A = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.float16).reshape(M, K).astype(np.float32)
+    B = np.fromfile(os.path.join(chkdir, 'in_b.bin'), np.float16).reshape(K, N).astype(np.float32)
+    D = (A @ B).astype(np.float64)
+    scale = fp19_to_f32(s['fp19'])
+    relu = s.get('relu', 'none')
+    if relu in ('lrelu', 'prelu'):
+        slope = fp19_to_f32(s['slope_fp19'])
+        # spec source_negative: value<0 -> slope; value>=0 (incl +0) -> scale.
+        mult = np.where(D < 0.0, slope, scale)
+    else:
+        mult = scale
+    act = D * mult
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    if s['qmode'] == 's8':
+        off = s.get('off', 0)
+        inter = np.clip(np.rint(act), -256, 255)          # S9 round+sat (RNE)
+        ref = np.clip(inter + off, -128, 127).astype(np.int64)
+        got = np.fromfile(out_path, np.int8).astype(np.int64).reshape(-1)[:ref.size]
+        itol = int(s.get('itol', 0))
+        d = np.abs(got - ref.reshape(-1))
+        bad = np.flatnonzero(d > itol)
+        if bad.size == 0:
+            return 0
+        i = int(bad[0])
+        print(f'[{case}] MQUANT-S8 MISMATCH {bad.size}/{ref.size} first@{i} '
+              f'got={got[i]} ref={ref.reshape(-1)[i]} (scale={scale} off={off} tol={itol})',
+              file=sys.stderr)
+        return 1
+    # f16 floating encode
+    ref = act.astype(np.float16).astype(np.float32).reshape(-1)
+    got = np.fromfile(out_path, np.float16).astype(np.float32).reshape(-1)[:ref.size]
+    eps = np.float32(s.get('eps', 3e-2))
+    atol = eps + eps * np.abs(ref)
+    bad = np.flatnonzero(np.abs(got - ref) > atol)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] MQUANT-F16 MISMATCH {bad.size}/{ref.size} first@{i} '
+          f'got={got[i]} ref={ref[i]} (scale={scale})', file=sys.stderr)
+    return 1
+
+def check_cscale(case, chkdir):
+    """TMATMUL_ACC + cscale golden (pto-spec cube.asl / matrix-postprocess.asl):
+    d = A@B + C / 2^exp (per-row exponent; here uniform exp)."""
+    s = REG[case]; M, N, K = s['M'], s['N'], s['K']
+    A = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.float16).reshape(M, K).astype(np.float32)
+    B = np.fromfile(os.path.join(chkdir, 'in_b.bin'), np.float16).reshape(K, N).astype(np.float32)
+    C = np.fromfile(os.path.join(chkdir, 'in_c.bin'), np.float32).reshape(M, N)
+    D = (A @ B) + C / np.float32(2.0 ** s['cexp'])
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    ref = D.astype(np.float32).reshape(-1)
+    got = np.fromfile(out_path, np.float32).reshape(-1)[:ref.size]
+    eps = np.float32(s.get('eps', 2e-2))
+    atol = eps + eps * np.abs(ref)
+    bad = np.flatnonzero(np.abs(got - ref) > atol)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] CSCALE MISMATCH {bad.size}/{ref.size} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_tpack(case, chkdir):
+    s = REG[case]
+    a = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.uint32).astype(np.uint64)
+    b = np.fromfile(os.path.join(chkdir, 'in_b.bin'), np.uint32).astype(np.uint64)
+    w0, w1 = s['w0'], s['w1']
+    m0 = (1 << (8 * w0)) - 1; m1 = (1 << (8 * w1)) - 1
+    ref = (((a & m0) | ((b & m1) << (8 * w0))) & 0xFFFFFFFF).astype(np.uint64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.uint32).astype(np.uint64).reshape(-1)[:ref.size]
+    bad = np.flatnonzero(got != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TPACK MISMATCH {bad.size}/{ref.size} first@{i} '
+          f'got=0x{int(got[i]):08x} ref=0x{int(ref.reshape(-1)[i]):08x}', file=sys.stderr)
+    return 1
+
+def check_tunpack(case, chkdir):
+    s = REG[case]
+    a = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.uint32).astype(np.uint64)
+    off, cnt = s['off'], s['cnt']
+    m = (1 << (8 * cnt)) - 1
+    ref = (((a >> (8 * off)) & m) & 0xFFFFFFFF).astype(np.uint64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.uint32).astype(np.uint64).reshape(-1)[:ref.size]
+    bad = np.flatnonzero(got != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TUNPACK MISMATCH {bad.size}/{ref.size} first@{i} '
+          f'got=0x{int(got[i]):08x} ref=0x{int(ref.reshape(-1)[i]):08x}', file=sys.stderr)
+    return 1
+
+def check_eqsrc(case, chkdir):
+    """TPERMUTE/TSHUF identity config: output must equal src (in_a), bit-exact."""
+    s = REG[case]; dt = s['dt']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), dt)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, dt).reshape(-1)[:a.size]
+    bad = np.flatnonzero(got != a.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] EQSRC MISMATCH {bad.size}/{a.size} first@{i} got={got[i]} ref={a.reshape(-1)[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_zeros(case, chkdir):
+    """TGPR2T sanity: all-zero planes -> all-zero U8 output."""
+    s = REG[case]; dt = s['dt']; n = s['M'] * s['N']
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, dt).reshape(-1)[:n]
+    bad = np.flatnonzero(got != 0)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] ZEROS MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref=0', file=sys.stderr)
+    return 1
+
+def check_iota(case, chkdir):
+    s = REG[case]; dt = s['dt']; vc = s['vc']; start = s['start']; desc = s['desc']
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, dt)[:vc]
+    k = np.arange(vc, dtype=np.int64)
+    seq = (start - k) if desc else (start + k)      # TCI.md: asc start+k / desc start-k
+    ref = seq.astype(NP[dt])                          # astype wraps modulo element width
+    bad = np.flatnonzero(got != ref)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TCI MISMATCH {bad.size}/{vc} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_cvt(case, chkdir):
+    s = REG[case]
+    a = np.fromfile(os.path.join(chkdir, 'in_a.bin'), NP[s['din']]).astype(np.float64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, s['dout']).astype(np.int64)
+    mode = s['round']
+    if mode == 'rne':
+        ref = np.rint(a)                 # round-half-to-even
+    elif mode == 'rtz':
+        ref = np.trunc(a)                # toward zero
+    elif mode == 'floor':
+        ref = np.floor(a)
+    elif mode == 'ceil':
+        ref = np.ceil(a)
+    else:
+        print(f'[{case}] unknown round mode {mode}', file=sys.stderr); return 2
+    ref = ref.astype(np.int64)
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] CVT MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]} src={a[i]} mode={mode}',
+          file=sys.stderr)
+    return 1
+
+def check_quant(case, chkdir):
+    s = REG[case]
+    a = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.float32).astype(np.float64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.int8).astype(np.int64)
+    q = np.rint(a * s['mult']) + s['zp']           # np.rint = round-half-to-even = RNE
+    ref = np.clip(q, -128, 127).astype(np.int64)
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] QUANT MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]} src={a[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_dequant(case, chkdir):
+    s = REG[case]
+    a = np.fromfile(os.path.join(chkdir, 'in_a.bin'), np.int8).astype(np.float64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.float32).astype(np.float64)
+    ref = (a - s['zp']) * s['mult']
+    n = min(got.size, ref.size)
+    eps = 1e-4 + 1e-4 * np.abs(ref[:n])
+    bad = np.flatnonzero(np.abs(got[:n] - ref[:n]) > eps)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] DEQUANT MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_transpose(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(N, M)
+    ref = a.T
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TRANSPOSE MISMATCH {bad.size} first@{i}', file=sys.stderr)
+    return 1
+
+def check_concat(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    b = np_read(os.path.join(chkdir, 'in_b.bin'), F32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, 2 * N)
+    ref = np.concatenate([a, b], axis=1)
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] CONCAT MISMATCH {bad.size} first@{i} got={got.reshape(-1)[i]} ref={ref.reshape(-1)[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_sort(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N)
+    ref = np.sort(a, axis=1)
+    if s.get('desc', 0):
+        ref = ref[:, ::-1]
+    eps = np.float32(s.get('eps', 1e-6))
+    bad = np.flatnonzero(np.abs(got - ref).reshape(-1) > eps)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] SORT MISMATCH {bad.size} first@{i} got={got.reshape(-1)[i]} ref={ref.reshape(-1)[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_expandarith(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']; op = s['op']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N).astype(np.float64)
+    braw = np_read(os.path.join(chkdir, 'in_b.bin'), F32).astype(np.float64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N).astype(np.float64)
+    if s['foot'] == 'row':
+        bc = braw[:M].reshape(M, 1)                 # per-row scalar, broadcast over cols
+    else:
+        bc = braw[:N].reshape(1, N)                  # per-col scalar (GENUINE 1 x N), over rows
+    fn = {'add': lambda x, y: x + y, 'sub': lambda x, y: x - y,
+          'mul': lambda x, y: x * y, 'div': lambda x, y: x / y,
+          'max': np.maximum, 'min': np.minimum,
+          'expdif': lambda x, y: np.exp(x - y)}[op]   # EXPDIF base-e (softmax)
+    ref = fn(a, bc)
+    eps = float(s.get('eps', 1e-4))
+    atol = eps + eps * np.abs(ref)
+    err = np.abs(got - ref)
+    print(f'[{case}] expandarith max_abs={err.max():.3e} '
+          f'max_rel={(err/(np.abs(ref)+1e-30)).max():.3e} eps={eps:.1e}', file=sys.stderr)
+    bad = np.flatnonzero(err.reshape(-1) > atol.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] EXPANDARITH MISMATCH {bad.size}/{ref.size} first@{i} '
+          f'got={got.reshape(-1)[i]} ref={ref.reshape(-1)[i]}', file=sys.stderr)
+    return 1
+
+def check_transcend(case, chkdir):
+    s = REG[case]
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).astype(np.float64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).astype(np.float64)
+    # Authoritative semantics (pto-spec normative ASL contract): TLOG = same-type
+    # NATURAL logarithm (ln) — docs/tile/.../transcendental/TLOG.md states "natural
+    # logarithm" 3x + log(1)=+0/log(0)=-inf/log(neg)=NaN; SuperNPUBench tlog.md and
+    # tileop-usage TLOG.md agree. golden pins the DESIGN intent (ln). The emulator
+    # currently computes log2 (measured TLOG(4.25)=2.0875) → this case is expected to
+    # land in PRECISION-FAIL, witnessing model gap gfrun-6 (NOT a golden regression).
+    # TEXP is base-e (matches spec + emulator).
+    fn = {'exp': np.exp, 'log': np.log, 'recip': lambda x: 1.0 / x,
+          'sqrt': np.sqrt, 'rsqrt': lambda x: 1.0 / np.sqrt(x)}[s['op']]
+    ref = fn(a)
+    n = min(got.size, ref.size)
+    got, ref = got[:n], ref[:n]
+    eps = float(s.get('eps', 3e-3))
+    atol = eps + eps * np.abs(ref)                    # relative + small absolute
+    err = np.abs(got - ref)
+    bad = np.flatnonzero(err > atol)
+    rel = err / (np.abs(ref) + 1e-30)
+    print(f'[{case}] transcend max_abs={err.max():.3e} max_rel={rel.max():.3e} eps={eps:.1e}',
+          file=sys.stderr)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TRANSCEND MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_gather(case, chkdir):
+    base = np.fromfile(os.path.join(chkdir, 'in_base.bin'), np.float32)
+    off = np.fromfile(os.path.join(chkdir, 'in_off.bin'), np.uint32).astype(np.int64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.float32)
+    ref = base[off // 4]                              # addr = base + byte displacement
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] GATHER MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_scatter(case, chkdir):
+    base = np.fromfile(os.path.join(chkdir, 'in_base.bin'), np.float32)
+    src = np.fromfile(os.path.join(chkdir, 'in_src.bin'), np.float32)
+    off = np.fromfile(os.path.join(chkdir, 'in_off.bin'), np.uint32).astype(np.int64)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.float32)
+    ref = base.copy()
+    ref[off // 4] = src                              # injective offsets -> deterministic
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] SCATTER MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_cas(case, chkdir):
+    s = REG[case]; ONE = s['OM'] * s['ON']
+    base0 = np.fromfile(os.path.join(chkdir, 'in_base.bin'), np.float32)
+    off = np.fromfile(os.path.join(chkdir, 'in_off.bin'), np.uint32).astype(np.int64)
+    exp = np.fromfile(os.path.join(chkdir, 'in_exp.bin'), np.float32)
+    rep = np.fromfile(os.path.join(chkdir, 'in_rep.bin'), np.float32)
+    old_path = os.path.join(chkdir, 'out.bin')
+    mem_path = os.path.join(chkdir, 'out_mem.bin')
+    if not os.path.exists(old_path) or not os.path.exists(mem_path):
+        print(f'[{case}] MISSING out.bin/out_mem.bin', file=sys.stderr); return 1
+    got_old = np.fromfile(old_path, np.float32)[:ONE]
+    got_mem = np.fromfile(mem_path, np.float32)
+    slot = off // 4
+    cur = base0[slot]                                   # pre-swap values (injective offsets)
+    hit = (cur == exp)                                  # CAS succeeds iff current == expected
+    # 1) observedOld is always the pre-swap value
+    ref_old = cur
+    bad = np.flatnonzero(got_old[:ONE] != ref_old)
+    if bad.size:
+        i = int(bad[0])
+        print(f'[{case}] CAS observedOld MISMATCH {bad.size}/{ONE} first@{i} '
+              f'got={got_old[i]} ref={ref_old[i]}', file=sys.stderr); return 1
+    # 2) backing after CAS: hit lanes -> replacement, miss lanes -> unchanged
+    ref_mem = base0.copy()
+    ref_mem[slot] = np.where(hit, rep, cur)
+    bad = np.flatnonzero(got_mem != ref_mem)
+    if bad.size:
+        i = int(bad[0])
+        print(f'[{case}] CAS backing MISMATCH {bad.size}/{ref_mem.size} first@slot{i} '
+              f'got={got_mem[i]} ref={ref_mem[i]}', file=sys.stderr); return 1
+    return 0
+
+def check_gather_mask(case, chkdir):
+    base = np.fromfile(os.path.join(chkdir, 'in_base.bin'), np.float32)
+    off = np.fromfile(os.path.join(chkdir, 'in_off.bin'), np.uint32).astype(np.int64)
+    mask = np.fromfile(os.path.join(chkdir, 'in_mask.bin'), np.uint8)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.float32)
+    ref = np.where(mask == 1, base[off // 4], np.float32(0.0)).astype(np.float32)
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] GATHER_MASK MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_scatter_mask(case, chkdir):
+    base = np.fromfile(os.path.join(chkdir, 'in_base.bin'), np.float32)
+    src = np.fromfile(os.path.join(chkdir, 'in_src.bin'), np.float32)
+    off = np.fromfile(os.path.join(chkdir, 'in_off.bin'), np.uint32).astype(np.int64)
+    mask = np.fromfile(os.path.join(chkdir, 'in_mask.bin'), np.uint8)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np.fromfile(out_path, np.float32)
+    ref = base.copy()
+    m = mask == 1
+    ref[(off // 4)[m]] = src[m]                       # injective offsets -> deterministic
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] SCATTER_MASK MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_extract(case, chkdir):
+    s = REG[case]
+    src = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(s['SM'], s['SN'])
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(s['DM'], s['DN'])
+    ref = src[s['OR']:s['OR'] + s['DM'], s['OC']:s['OC'] + s['DN']]
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] EXTRACT MISMATCH {bad.size} first@{i}', file=sys.stderr)
+    return 1
+
+def check_mrgsort(case, chkdir):
+    s = REG[case]; H, W = s['H'], s['W']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32)
+    b = np_read(os.path.join(chkdir, 'in_b.bin'), F32)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32)
+    ref = np.sort(np.concatenate([a[:H], b[:H]]))          # stable ascending merge
+    n = min(got.size, ref.size, W)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] MRGSORT MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_tgather(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    val = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    idx = np_read(os.path.join(chkdir, 'in_idx.bin'), I32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N)
+    c = np.arange(N)[None, :]
+    ref = val[idx, c]                                      # dst[r,c] = val[idx[r,c], c]
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TGATHER MISMATCH {bad.size} first@{i}', file=sys.stderr)
+    return 1
+
+def check_tscatter(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    src = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    idx = np_read(os.path.join(chkdir, 'in_idx.bin'), I32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N)
+    ref = np.zeros((M, N), np.float32)
+    c = np.broadcast_to(np.arange(N)[None, :], (M, N))
+    ref[idx, c] = src                                     # dst[idx[r,c], c] = src[r,c]
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TSCATTER MISMATCH {bad.size} first@{i}', file=sys.stderr)
+    return 1
+
+def check_insert(case, chkdir):
+    s = REG[case]
+    base = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(s['DM'], s['DN'])
+    patch = np_read(os.path.join(chkdir, 'in_b.bin'), F32).reshape(s['SM'], s['SN'])
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(s['DM'], s['DN'])
+    ref = base.copy()
+    ref[s['OR']:s['OR'] + s['SM'], s['OC']:s['OC'] + s['SN']] = patch
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] INSERT MISMATCH {bad.size} first@{i}', file=sys.stderr)
+    return 1
+
+def _cmp_mask(mode, a, rhs):
+    if mode == 'gt': return a > rhs
+    if mode == 'lt': return a < rhs
+    if mode == 'ge': return a >= rhs
+    if mode == 'le': return a <= rhs
+    if mode == 'eq': return a == rhs
+    if mode == 'ne': return a != rhs
+    raise KeyError(mode)
+
+def check_cmpsel(case, chkdir):
+    s = REG[case]
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), I32)
+    if s['fam'] == 'cmpsel':
+        b = np_read(os.path.join(chkdir, 'in_b.bin'), I32)
+        prior = np_read(os.path.join(chkdir, 'in_c.bin'), I32)
+        tru = np_read(os.path.join(chkdir, 'in_d.bin'), I32)
+        mask = _cmp_mask(s['mode'], a, b)
+    else:
+        prior = np_read(os.path.join(chkdir, 'in_b.bin'), I32)
+        tru = np_read(os.path.join(chkdir, 'in_c.bin'), I32)
+        mask = _cmp_mask(s['mode'], a, np.int32(s['scalar']))
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, I32)
+    ref = np.where(mask, tru, prior).astype(np.int32)
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] CMPSEL MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_copyexpand(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N)
+    raw = np_read(os.path.join(chkdir, 'in_a.bin'), F32)
+    if s['foot'] == 'row':
+        col = raw[:M].reshape(M, 1)                             # M x 1 broadcast column
+        ref = np.repeat(col, N, axis=1)                        # dst[r,c] = src[r]
+    else:
+        row0 = raw[:N].reshape(1, N)                           # GENUINE 1 x N broadcast row
+        ref = np.repeat(row0, M, axis=0)                       # dst[r,c] = src[c]
+    eps = np.float32(s.get('eps', 1e-4))
+    atol = eps + eps * np.abs(ref)
+    bad = np.flatnonzero(np.abs(got - ref) > atol)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] COPYEXPAND MISMATCH {bad.size} first@{i}', file=sys.stderr)
+    return 1
+
+def check_argreduce(case, chkdir):
+    s = REG[case]; M, N = s['M'], s['N']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    o = np_read(out_path, U32)
+    fn = np.argmax if s['op'] == 'max' else np.argmin
+    if s['foot'] == 'row':
+        ref = fn(a, axis=1).astype(np.uint32)      # per-row -> length M
+        got = o[:M]                                 # genuine M x 1 dst (ops-20260904)
+    else:
+        ref = fn(a, axis=0).astype(np.uint32)       # per-col -> length N
+        got = o[:N]                                 # genuine 1 x N dst (ops-20260904)
+    bad = np.flatnonzero(got.astype(np.int64) != ref.astype(np.int64))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] ARGREDUCE MISMATCH {bad.size} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_tsels(case, chkdir):
+    s = REG[case]
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), I32)
+    b = np_read(os.path.join(chkdir, 'in_b.bin'), I32)
+    src = np_read(os.path.join(chkdir, 'in_c.bin'), I32)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, I32)
+    mask = _cmp_mask(s['mode'], a, b)
+    ref = np.where(mask, src, np.int32(s['scalar'])).astype(np.int32)   # dst = mask ? src : SVAL
+    n = min(got.size, ref.size)
+    bad = np.flatnonzero(got[:n] != ref[:n])
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TSELS MISMATCH {bad.size}/{n} first@{i} got={got[i]} ref={ref[i]}',
+          file=sys.stderr)
+    return 1
+
+def check_fillpad(case, chkdir):
+    s = REG[case]; M, N, VR, VC = s['M'], s['N'], s['VR'], s['VC']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32).reshape(M, N)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N)
+    ref = np.zeros((M, N), np.float32)
+    ref[:VR, :VC] = a[:VR, :VC]                       # copy valid rect, zero the pad
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] FILLPAD MISMATCH {bad.size}/{M*N} first@{i} '
+          f'got={got.reshape(-1)[i]} ref={ref.reshape(-1)[i]}', file=sys.stderr)
+    return 1
+
+def check_regionasm(case, chkdir):
+    s = REG[case]; PM, PN, FN, NF = s['PM'], s['PN'], s['FN'], s['NF']
+    a = np_read(os.path.join(chkdir, 'in_a.bin'), F32)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(PM, PN)
+    frags = [a[k * PM * FN:(k + 1) * PM * FN].reshape(PM, FN) for k in range(NF)]
+    ref = np.concatenate(frags, axis=1)               # PM x (NF*FN) column concat
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] REGIONASM MISMATCH {bad.size}/{PM*PN} first@{i} '
+          f'got={got.reshape(-1)[i]} ref={ref.reshape(-1)[i]}', file=sys.stderr)
+    return 1
+
+def check_ttri(case, chkdir):
+    s = REG[case]; M, N, diag = s['M'], s['N'], s['diag']
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, F32).reshape(M, N)
+    r = np.arange(M)[:, None]; c = np.arange(N)[None, :]
+    mask = (c >= r + diag) if s['upper'] else (c <= r + diag)   # ASL: lower iff c<=r+diag
+    ref = mask.astype(np.float32)
+    bad = np.flatnonzero(got.reshape(-1) != ref.reshape(-1))
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] TTRI MISMATCH {bad.size}/{M*N} first@{i} '
+          f'got={got.reshape(-1)[i]} ref={ref.reshape(-1)[i]}', file=sys.stderr)
+    return 1
+
+def check(case, chkdir):
+    s = REG[case]
+    if s['fam'] == 'matmul':
+        return check_matmul(case, chkdir)
+    if s['fam'] == 'mquant':
+        return check_mquant(case, chkdir)
+    if s['fam'] == 'cscale':
+        return check_cscale(case, chkdir)
+    if s['fam'] == 'tpack':
+        return check_tpack(case, chkdir)
+    if s['fam'] == 'tunpack':
+        return check_tunpack(case, chkdir)
+    if s['fam'] == 'eqsrc':
+        return check_eqsrc(case, chkdir)
+    if s['fam'] == 'zeros':
+        return check_zeros(case, chkdir)
+    if s['fam'] == 'fillpad':
+        return check_fillpad(case, chkdir)
+    if s['fam'] == 'regionasm':
+        return check_regionasm(case, chkdir)
+    if s['fam'] == 'ttri':
+        return check_ttri(case, chkdir)
+    if s['fam'] == 'tsels':
+        return check_tsels(case, chkdir)
+    if s['fam'] == 'argreduce':
+        return check_argreduce(case, chkdir)
+    if s['fam'] == 'copyexpand':
+        return check_copyexpand(case, chkdir)
+    if s['fam'] in ('cmpsel', 'cmpsel_s'):
+        return check_cmpsel(case, chkdir)
+    if s['fam'] == 'extract':
+        return check_extract(case, chkdir)
+    if s['fam'] == 'insert':
+        return check_insert(case, chkdir)
+    if s['fam'] == 'mrgsort':
+        return check_mrgsort(case, chkdir)
+    if s['fam'] == 'tgather':
+        return check_tgather(case, chkdir)
+    if s['fam'] == 'tscatter':
+        return check_tscatter(case, chkdir)
+    if s['fam'] == 'reduce':
+        return check_reduce(case, chkdir)
+    if s['fam'] == 'iota':
+        return check_iota(case, chkdir)
+    if s['fam'] == 'transcend':
+        return check_transcend(case, chkdir)
+    if s['fam'] == 'expandarith':
+        return check_expandarith(case, chkdir)
+    if s['fam'] == 'cvt':
+        return check_cvt(case, chkdir)
+    if s['fam'] == 'quant':
+        return check_quant(case, chkdir)
+    if s['fam'] == 'dequant':
+        return check_dequant(case, chkdir)
+    if s['fam'] == 'transpose':
+        return check_transpose(case, chkdir)
+    if s['fam'] == 'concat':
+        return check_concat(case, chkdir)
+    if s['fam'] == 'sort':
+        return check_sort(case, chkdir)
+    if s['fam'] == 'gather':
+        return check_gather(case, chkdir)
+    if s['fam'] == 'scatter':
+        return check_scatter(case, chkdir)
+    if s['fam'] == 'cas':
+        return check_cas(case, chkdir)
+    if s['fam'] == 'gather_mask':
+        return check_gather_mask(case, chkdir)
+    if s['fam'] == 'scatter_mask':
+        return check_scatter_mask(case, chkdir)
+    r, out_dt = ref(case, chkdir)
+    out_path = os.path.join(chkdir, 'out.bin')
+    if not os.path.exists(out_path):
+        print(f'[{case}] MISSING out.bin', file=sys.stderr); return 1
+    got = np_read(out_path, out_dt)
+    r = r.astype(NP[out_dt]).reshape(-1)
+    got = got.reshape(-1)[:r.size]
+    if out_dt == I32:
+        bad = np.flatnonzero(got != r)
+    else:
+        eps = np.float32(s.get('eps', 1e-4))
+        atol = eps + eps * np.abs(r.astype(np.float32))
+        bad = np.flatnonzero(np.abs(got.astype(np.float32) - r.astype(np.float32)) > atol)
+    if bad.size == 0:
+        return 0
+    i = int(bad[0])
+    print(f'[{case}] MISMATCH {bad.size}/{r.size}  first@{i} got={got[i]} ref={r[i]}',
+          file=sys.stderr)
+    return 1
+
+def main():
+    if len(sys.argv) < 4:
+        print('usage: golden.py gen|check <case> <chkdir>', file=sys.stderr); return 2
+    mode, case, chkdir = sys.argv[1], sys.argv[2], sys.argv[3]
+    if case not in REG:
+        # not registered => no golden for this case (run-only). Signal via 3.
+        return 3
+    if mode == 'gen':   gen(case, chkdir);   return 0
+    if mode == 'check': return check(case, chkdir)
+    print('unknown mode', mode, file=sys.stderr); return 2
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/benchmark/one-level-arch/test/solution/tileop-test/misc/Makefile
+++ b/benchmark/one-level-arch/test/solution/tileop-test/misc/Makefile
@@ -1,0 +1,3 @@
+SRC_FILE = src/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)/$(TESTCASE).elf
+include ../Makefile.common

--- a/benchmark/one-level-arch/test/solution/tileop-test/misc/src/reinterpret_tcmp.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/misc/src/reinterpret_tcmp.cpp
@@ -1,0 +1,53 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: reinterpret_tile + TCMP — WITNESS of a model-side gap.
+// Same both-views bitcast usage as reinterpret_tile.cpp (TANDS), but the
+// consuming op is TCMP: bitcast two fp32 tiles to int32 views and compare their
+// bit patterns (TCMP<GT> on the int32 views -> predicate), consume with TSEL,
+// store the select result. Would-be golden = where(int_bits(a)>int_bits(b), tru, prior).
+//
+// STATUS (run-fail, genuine model gap): TCMP<tile_out,tile_in> has SEPARATE
+// out/in template params, so a plain predicate dst + two int32 VIEW sources
+// COMPILES. But the emulator's TCMP handler rejects the view sources at runtime:
+//   gfrun: "TCMP requires two compatible Tile sources"
+//          (IsCompatibleDataTile on srcs[1]/srcs[2], before any store).
+// Contrast: the SAME views feed TANDS fine (reinterpret_tile.cpp PASSES), and
+// plain int32 tiles feed TCMP fine (vec/tcmp PASSES) — so the view source is the
+// differentiator. This is the one spot the official reinterpret fix missed, at
+// the model/emulator layer (compiler/header already accept the view). File as a
+// [gfrun][NA] issue; this case flips to PASS once the TCMP handler accepts
+// reinterpret-view sources like TANDS does.
+constexpr int M = 16, N = 16, NE = M * N;
+static float A[NE], B[NE];
+static int32_t prior[NE], tru[NE], out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", A, sizeof(A));
+    guard_read_bin(CHK_DIR "/in_b.bin", B, sizeof(B));
+    guard_read_bin(CHK_DIR "/in_c.bin", prior, sizeof(prior));
+    guard_read_bin(CHK_DIR "/in_d.bin", tru, sizeof(tru));
+#else
+    for (int i = 0; i < NE; ++i) { A[i] = (float)i * 0.5f; B[i] = (float)((i * 3) % 17); prior[i] = -i - 1; tru[i] = i + 100; }
+#endif
+    iter_t<float, M, N> gA(A), gB(B);
+    iter_t<int32_t, M, N> gP(prior), gT(tru), gO(out);
+    auto a0 = gA(0, 0), b0 = gB(0, 0);
+    auto p0 = gP(0, 0), t0 = gT(0, 0), o0 = gO(0, 0);
+    vtile_t<float, M, N> tA, tB;
+    vtile_t<int32_t, M, N> tMask, tD, tTru;
+    TLOAD(tA, a0);
+    TLOAD(tB, b0);
+    TLOAD(tD, p0);         // dst prior = false source (TSEL in-place)
+    TLOAD(tTru, t0);
+    BENCHSTART;
+    auto vA = reinterpret_tile<int32_t>(tA);   // fp32 bits as int32
+    auto vB = reinterpret_tile<int32_t>(tB);
+    TCMP<CmpMode::GT>(tMask, vA, vB);          // <-- model rejects the view sources here
+    TSEL(tD, tMask, tTru);                     // dst = mask ? tru : prior
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/misc/src/reinterpret_tile.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/misc/src/reinterpret_tile.cpp
@@ -1,0 +1,40 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: reinterpret_tile<NewDType>(src) — zero-instruction bitcast view.
+// reinterpret_tile returns a ReinterpretedTileView (a distinct view type; is_tile
+// is true). Tileop templates bind BOTH operands to the SAME tile_shape, so a view
+// cannot be mixed with a plain Tile in one call — that is the reported
+// "no matching function for call to 'TABS'". Correct usage: reinterpret BOTH
+// operands so they share the view type. TANDS accepts the views fine. The store
+// pattern follows the model's own cross_model test
+// (bf16_backing_tands_u16_then_tmuls_bf16): after the integer-view op the backing
+// carries the INT32 runtime dtype tag, so a subsequent NATIVE-type op is used to
+// re-tag the backing back to FP32 before TSTORE (TSTORE keys the block dtype off
+// the tile's declared type and rejects view operands). Here:
+//   bitcast fp32->int32 view; TANDS &0x7fffffff (clear sign -> |x| bits);
+//   TMULS(tOut, tOut, 1.0f) re-tags FP32; TSTORE fp32.  golden = abs.
+// (The TCMP variant of this pattern is a model gap — see reinterpret_tcmp.cpp.)
+constexpr int M = 16, N = 16, NE = M * N;
+static float in[NE], out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", in, sizeof(in));
+#else
+    for (int i = 0; i < NE; ++i) in[i] = (i % 2 ? -1.f : 1.f) * (float)i * 0.5f;
+#endif
+    iter_t<float, M, N> gI(in), gO(out);
+    auto i0 = gI(0, 0), o0 = gO(0, 0);
+    vtile_t<float, M, N> tIn, tOut;
+    TLOAD(tIn, i0);
+    BENCHSTART;
+    auto vIn = reinterpret_tile<int32_t>(tIn);     // fp32 bits viewed as int32
+    auto vOut = reinterpret_tile<int32_t>(tOut);   // same view type as vIn
+    TANDS(vOut, vIn, (int32_t)0x7fffffff);         // clear sign bit -> |x| (backing tagged INT32)
+    TMULS(tOut, tOut, 1.0f);                       // native fp32 op re-tags backing FP32
+    BENCHEND;
+    TSTORE(o0, tOut);                              // fp32 store now matches -> |x|
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/README.md
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/README.md
@@ -1,0 +1,40 @@
+# 已退休直接 Tile op —— 从活跃看护隔离
+
+这些 op 已由 PTO-SPEC 从**活跃直接 Tile 指令集**退休（对应 tile ASL 已删）。它们**不应再作为活跃接口看护**：
+正确闭环是 API/Bench 改用软件序列或 fail-closed，模型侧拒绝退休 selector（`tile-fault-retired-encodings-001.asl`）。
+demo 移到此处保留作历史，`run_guard.sh` 只遍历各域 `src/*.cpp`，故不再拾取这些 case。
+
+判据：当前 pto-spec `asl/tile/` 下已无对应活跃 ASL（对比 TPACK/TPERMUTE 仍在=未退休）。
+
+## 清单（15 个）
+
+### ADR-TILE-0013 / 提交 `edcbd8b`（发布 0.58.5.1，"software-replaceable tile operations"，Tile op 126→118 / TEPL selector 86→78）
+| 算子 | 类别 |
+|---|---|
+| TCONCAT | 拼接 |
+| TEXTRACT | 抽取 |
+| TINSERT | 插入 |
+| THISTOGRAM | 直方图 |
+| TQUANT | 量化 |
+| TDEQUANT | 反量化 |
+| TSORT | 排序 |
+| TMRGSORT | 归并排序 |
+
+### ADR-CUBE-0013（private cube/vector/cell rearrangement；reserved-illegal，no alias/replacement）
+| 算子 | 退休 selector |
+|---|---|
+| TPARTADD | 0x071..74 六个旧 selector 之一 |
+| TPARTMUL | 0x071..74 |
+| TPARTMAX | 0x071..74 |
+| TPARTMIN | 0x071..74 |
+| TFILLPAD | 0x065 |
+| TTRANS | 0x06E |
+
+### ADR-BLOCK-0018（Issue #99）
+| 算子 | 说明 |
+|---|---|
+| TIMG2COL | **Local-Tile 直接形式退休**，改由块形式 `BSTART.TIMG2COL` 承载 |
+
+## 影响修正
+此前这些被当活跃接口看护，其中 tconcat/tdequant/tsort/ttrans/tfillpad/tpart* 还"PASS"着——实为在验废弃指令；
+tquant/tinsert 曾被误报为模型缺口（#560 gfrun-6/7，已作废）。隔离后活跃看护不再包含退休 op。

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tconcat.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tconcat.cpp
@@ -1,0 +1,23 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCONCAT (SFU layout) — column concatenation.
+// (dst,s0,s1); dst cols = s0.cols + s1.cols (M x N ++ M x N -> M x 2N).
+// Precision: res_check, independent golden = horizontal concat [a | b].
+static float gA[16 * 8], gB[16 * 8], gC[16 * 16];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", gA, sizeof(gA));
+    guard_read_bin(CHK_DIR "/in_b.bin", gB, sizeof(gB));
+    constexpr int M = 16, N = 8;
+    iter_t<float, M, N> ggA(gA), ggB(gB);
+    iter_t<float, M, 2 * N> ggC(gC);
+    auto a0 = ggA(0, 0);
+    auto b0 = ggB(0, 0);
+    auto c0 = ggC(0, 0);
+    vtile_t<float, M, N> tA, tB;
+    vtile_t<float, M, 2 * N> tC;
+    TLOAD(tA, a0);
+    TLOAD(tB, b0);
+    BENCHSTART; TCONCAT(tC, tA, tB); BENCHEND;
+    TSTORE(c0, tC);
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tdequant.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tdequant.cpp
@@ -1,0 +1,8 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TDEQUANT (SFU) — S8 -> FP32.
+// Source: quant-and-im2col.md full signature TDEQUANT<Mode>(dst,src,mult,zp).
+// Semantics: dst = (src - zeroPoint) * multiplier. mult=2.0, zp=0.
+// Precision: res_check, independent numpy golden.
+GUARD_UNARY_CVT(int8_t, float, 8, 256, [](auto& d, auto& s){
+    TDEQUANT<RoundMode::RTZ>(d, s, 2.0f, 0);
+})

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/textract.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/textract.cpp
@@ -1,0 +1,34 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TEXTRACT — extract a sub-tile at (indexRow, indexCol).
+// v0.58 signature: TEXTRACT(dst, src, int32_t indexRow, int32_t indexCol).
+//   dst[j,i] = src[indexRow+j, indexCol+i]   (sub-tile copy).
+// docs/tileop-usage layout.md gives NO C++ signature; the 4-arg form (and the
+// index-offset semantics) is recovered from the header contract. Precision:
+// res_check; host owns src; numpy golden extracts the same block.
+constexpr int SM = 16, SN = 32, SNE = SM * SN;   // src 16x32
+constexpr int DM = 8,  DN = 16, DNE = DM * DN;   // dst 8x16
+constexpr int OR = 4, OC = 8;                    // extract offset (row,col)
+static float src[SNE], out[DNE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#else
+    for (int i = 0; i < SNE; ++i) src[i] = (float)i;
+#endif
+    iter_t<float, SM, SN> gS(src);
+    iter_t<float, DM, DN> gO(out);
+    auto gS0 = gS(0, 0);
+    auto gO0 = gO(0, 0);
+    vtile_t<float, SM, SN> tS;
+    vtile_t<float, DM, DN> tD;
+    TLOAD(tS, gS0);
+    BENCHSTART;
+    TEXTRACT(tD, tS, OR, OC);
+    BENCHEND;
+    TSTORE(gO0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tfillpad.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tfillpad.cpp
@@ -1,0 +1,28 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TFILLPAD — copy the VALID source rectangle into dst and fill
+// the physical padding with zero. Authoritative semantics: TFILLPAD.md ("复制有效
+// 源区域, 并将绑定的标量写入 padding") + its worked example (InputTile valid 9x9 in
+// a 16x16 physical, OutputTile PadValue::Zero); cpu_sim TFillPad.hpp static_assert
+// PadVal==Zero confirms zero-pad only. Signature + tile-shape recipe are taken
+// verbatim from the doc example. Precision: res_check; golden = zero-padded copy
+// of the VR x VC valid rectangle (dst[i,j]=src[i,j] for i<VR & j<VC, else 0).
+constexpr int M = 16, N = 16, VR = 9, VC = 9, NE = M * N;
+static float gin[NE], gout[NE];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", gin, sizeof(gin));
+    using GM = global_tensor<float, RowMajor<M, N>>;
+    using InputTile  = Tile<Location::Vec, float, M, N, BLayout::RowMajor, VR, VC>;
+    using OutputTile = Tile<Location::Vec, float, M, N, BLayout::RowMajor,
+                            M, N, SLayout::NoneBox, 512, PadValue::Zero>;
+    GM gsrc(gin), gdst(gout);
+    InputTile src;
+    OutputTile dst;
+    TLOAD(src, gsrc);
+    BENCHSTART;
+    TFILLPAD(dst, src);
+    BENCHEND;
+    TSTORE(gdst, dst);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/thistogram.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/thistogram.cpp
@@ -1,0 +1,36 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: THISTOGRAM — byte-indexed histogram.
+// v0.58 signature: THISTOGRAM(dst, src, Idx, int ByteId).
+//   Two source tiles (data src + index Idx) + a ByteId selector (0..3); output
+//   defaults to UINT32 bins. docs/tileop-usage gives NO signature; 4-arg form
+//   recovered from the header. Bin/accumulation semantics are not pinned by
+//   docs, so this stays a run-only stability guard (no golden).
+constexpr int M = 16, N = 16, NE = M * N;
+static int32_t src[NE], idx[NE];
+static uint32_t out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+    guard_read_bin(CHK_DIR "/in_b.bin", idx, sizeof(idx));
+#else
+    for (int i = 0; i < NE; ++i) { src[i] = (i * 7) % 251; idx[i] = i % N; }
+#endif
+    iter_t<int32_t, M, N> gS(src), gX(idx);
+    iter_t<uint32_t, M, N> gO(out);
+    auto gS0 = gS(0, 0);
+    auto gX0 = gX(0, 0);
+    auto gO0 = gO(0, 0);
+    vtile_t<int32_t, M, N> tS, tX;
+    vtile_t<uint32_t, M, N> tD;
+    TLOAD(tS, gS0);
+    TLOAD(tX, gX0);
+    BENCHSTART;
+    THISTOGRAM(tD, tS, tX, 0);
+    BENCHEND;
+    TSTORE(gO0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/timg2col.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/timg2col.cpp
@@ -1,0 +1,38 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TIMG2COL (image-to-column, the convolution primitive).
+// Source: docs/tileop-usage/layout-and-rearrangement/layout/TIMG2COL.md — FULL
+//   signature + example. Written STRICTLY from that example (a plain Location::Vec
+//   RowMajor tile loaded via TLOAD, then TIMG2COL(dst, src, posM, posK)):
+//     using GM   = global_tensor<float, RowMajor<8, 256>>;
+//     using TileT= Tile<Location::Vec, float, 8, 256, BLayout::RowMajor>;
+//     TLOAD(src, src_global); TIMG2COL(dst, src, 3, 5);
+//   The doc example does NOT construct a persistent Matrix-location feature-map
+//   descriptor source; we deliberately do NOT invent one (that would require
+//   reading the ISA/ASL, out of scope for a doc-driven guard).
+// STATUS: on the env_test model TIMG2COL is a fail-closed assertion stub
+//   (convolution window / repeat / padding contract not implemented), so this
+//   doc-faithful demo reaches gfrun and aborts -> run-fail. Recorded in REPORT
+//   as "doc example does not run on the current model".
+constexpr int GM = 8, GN = 256, GNE = GM * GN;
+static float src_data[GNE], out[GNE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src_data, sizeof(src_data));
+#else
+    guard_fill_seq_f32(src_data, GNE, 1.0f, 0.1f);
+#endif
+    iter_t<float, GM, GN> gSrc(src_data), gOut(out);
+    auto gSrc0 = gSrc(0, 0);
+    auto gOut0 = gOut(0, 0);
+    vtile_t<float, GM, GN> src, dst;
+    TLOAD(src, gSrc0);
+    BENCHSTART;
+    TIMG2COL(dst, src, /*posM=*/3, /*posK=*/5);
+    BENCHEND;
+    TSTORE(gOut0, dst);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tinsert.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tinsert.cpp
@@ -1,0 +1,39 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TINSERT — insert a sub-tile at (indexRow, indexCol).
+// v0.58 signature: TINSERT(dst, src, int32_t indexRow, int32_t indexCol).
+//   dst[indexRow+j, indexCol+i] = src[j,i]; the rest of dst is preserved
+//   (in-place patch), so dst must be pre-loaded with a base tile.
+// docs/tileop-usage layout.md gives NO C++ signature; 4-arg index-offset form
+// recovered from the header contract. Precision: res_check; host owns base +
+// patch; numpy golden overwrites the same window.
+constexpr int DM = 16, DN = 32, DNE = DM * DN;   // dst base 16x32
+constexpr int SM = 8,  SN = 16, SNE = SM * SN;   // patch 8x16
+constexpr int OR = 4, OC = 8;                    // insert offset (row,col)
+static float base[DNE], patch[SNE], out[DNE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", base, sizeof(base));
+    guard_read_bin(CHK_DIR "/in_b.bin", patch, sizeof(patch));
+#else
+    for (int i = 0; i < DNE; ++i) base[i] = (float)i;
+    for (int i = 0; i < SNE; ++i) patch[i] = -(float)(i + 1);
+#endif
+    iter_t<float, DM, DN> gB(base), gO(out);
+    iter_t<float, SM, SN> gP(patch);
+    auto gB0 = gB(0, 0);
+    auto gP0 = gP(0, 0);
+    auto gO0 = gO(0, 0);
+    vtile_t<float, DM, DN> tD;
+    vtile_t<float, SM, SN> tP;
+    TLOAD(tD, gB0);        // dst base (preserved outside the window)
+    TLOAD(tP, gP0);        // patch
+    BENCHSTART;
+    TINSERT(tD, tP, OR, OC);
+    BENCHEND;
+    TSTORE(gO0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tmrgsort.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tmrgsort.cpp
@@ -1,0 +1,42 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TMRGSORT (SFU irregular) — merge two sorted rows.
+// Source: docs/tileop-usage/sort.md — FULL signature given.
+//   template <DstTile, LeftTile, RightTile>
+//   void TMRGSORT(dst, left, right, descending=false);
+// Authoritative semantics (pto-spec normative ASL, irregular-and-complex/sorting):
+//   "stably merge two sorted single-row Local streams into one destination".
+//   -> dst = ascending-merge(left, right) = sorted(concat(left,right)) for sorted
+//   inputs. NOTE(doc-example-bug): sort.md example uses 1x256 for all three, but a
+//   static_assert requires dst.ValidCol == left.ValidCol + right.ValidCol; correct
+//   shapes are two 1x128 sources merged into a 1x256 dst.
+// Precision: res_check READY golden — TMRGSORT is currently an unimplemented model
+// stub (run-fail); when the model implements it, check_mrgsort auto-validates.
+constexpr int H = 128, W = 256;
+static float a[H], b[H], out[W];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", a, sizeof(a));   // ascending-sorted left
+    guard_read_bin(CHK_DIR "/in_b.bin", b, sizeof(b));   // ascending-sorted right
+#else
+    for (int i = 0; i < H; ++i) { a[i] = (float)(2 * i); b[i] = (float)(2 * i + 1); }
+#endif
+    gzero(out, W);
+    iter_t<float, 1, H> gA((float *)a), gB((float *)b);
+    iter_t<float, 1, W> gO(out);
+    auto gA0 = gA(0, 0);
+    auto gB0 = gB(0, 0);
+    auto gO0 = gO(0, 0);
+    vtile_t<float, 1, H> tA, tB;
+    vtile_t<float, 1, W> tO;
+    TLOAD(tA, gA0);
+    TLOAD(tB, gB0);
+    BENCHSTART;
+    TMRGSORT(tO, tA, tB);              // ascending merge
+    BENCHEND;
+    TSTORE(gO0, tO);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartadd.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartadd.cpp
@@ -1,0 +1,6 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TPARTADD (SFU irregular) — elementwise add over the
+// common valid region. "PART" = partial-valid-region (docs/intrinsics/tpartadd.md),
+// NOT a segmented reduction. Full-valid 16x16 => plain elementwise add.
+// Precision: res_check, independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TPARTADD(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartmax.cpp
@@ -1,0 +1,6 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TPARTMAX (SFU irregular) — elementwise max over the
+// common valid region. "PART" = partial-valid-region (docs/intrinsics/tpartmax.md),
+// NOT a segmented reduction. Full-valid 16x16 => plain elementwise max.
+// Precision: res_check, independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TPARTMAX(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartmin.cpp
@@ -1,0 +1,6 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TPARTMIN (SFU irregular) — elementwise min over the
+// common valid region. "PART" = partial-valid-region (docs/intrinsics/tpartmin.md),
+// NOT a segmented reduction. Full-valid 16x16 => plain elementwise min.
+// Precision: res_check, independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TPARTMIN(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartmul.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tpartmul.cpp
@@ -1,0 +1,6 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TPARTMUL (SFU irregular) — elementwise mul over the
+// common valid region. "PART" = partial-valid-region (docs/intrinsics/tpartmul.md),
+// NOT a segmented reduction. Full-valid 16x16 => plain elementwise mul.
+// Precision: res_check, independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TPARTMUL(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tquant.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tquant.cpp
@@ -1,0 +1,13 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TQUANT (SFU) — FP32 -> S8, RNE + saturate.
+// Source: quant-and-im2col.md full signature TQUANT<Mode,Sat>(dst,src,mult,zp).
+// Authoritative semantics (pto-spec normative ASL, format-conversion/TQUANT.md):
+//   q = clamp(round_RNE(src*multiplier + zeroPoint), -128, 127); multiplier and
+//   zeroPoint are NORMATIVELY MANDATORY (only an omitted B.IOR defaults to 1.0/0).
+// So this demo passes REAL non-identity mult/zp (0.5f, 1) per spec, and the golden
+// asserts the full quant. The emulator currently IGNORES mult/zp (output equals
+// clamp(round_RNE(src))), so this case is expected to land in PRECISION-FAIL,
+// witnessing model gap gfrun-5 (not a golden/demo regression). Input spans +-256.
+GUARD_UNARY_CVT(float, int8_t, 8, 256, [](auto& d, auto& s){
+    TQUANT<RoundMode::RNE, /*saturate=*/true>(d, s, 0.5f, 1);
+})

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/tsort.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/tsort.cpp
@@ -1,0 +1,24 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSORT (SFU irregular) — per-row sort, width=32 ascending.
+// Source: sort.md full signature TSORT(valueDst, indexDst, source, width, desc).
+// Precision: res_check checks sorted VALUES (out.bin); distinct per-row inputs
+// make the ordering unambiguous. valueDst/source FP32, indexDst U32.
+static float gS[32 * 32], gV[32 * 32];
+static uint32_t gI[32 * 32];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", gS, sizeof(gS));
+    constexpr int M = 32, N = 32;
+    iter_t<float, M, N> ggS(gS), ggV(gV);
+    iter_t<uint32_t, M, N> ggI(gI);
+    auto s0 = ggS(0, 0);
+    auto v0 = ggV(0, 0);
+    auto i0 = ggI(0, 0);
+    vtile_t<float, M, N> tS, tV;
+    vtile_t<uint32_t, M, N> tI;
+    TLOAD(tS, s0);
+    BENCHSTART; TSORT(tV, tI, tS); BENCHEND;
+    TSTORE(v0, tV);
+    TSTORE(i0, tI);
+    guard_dump_bin(CHK_DIR "/out.bin", gV, sizeof(gV));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/retired/ttrans.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/retired/ttrans.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TTRANS (SFU layout) — transpose.
+// Source: layout.md lists TTRANS as SFU op, no signature; (dst,src) inferred.
+// Square 16x16 avoids NxM shape ambiguity. Precision: res_check, golden = src^T.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TTRANS(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/run_guard.sh
+++ b/benchmark/one-level-arch/test/solution/tileop-test/run_guard.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# TileOP-guard batch runner (res_check precision path).
+# Per case: compile -> golden.py gen (host inputs) -> gfrun (reads inputs, dumps
+# out.bin) -> golden.py check (independent numpy compare). Classify:
+#   compile-fail | run-fail(crash, no end marker) | precision-fail | pass | run-only
+# A case is golden-checked iff registered in golden/golden.py (gen rc!=3).
+#
+# Usage: bash run_guard.sh <subdir> [case]
+# Requires: COMPILER_DIR (linx toolchain bin), GFRUN (gfrun binary).
+set -u
+
+SUB="${1:?usage: run_guard.sh <subdir> [case]}"
+ONLY="${2:-}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GUARD_ROOT="$HERE"
+SUBDIR="$GUARD_ROOT/$SUB"
+GOLDEN="$GUARD_ROOT/golden/golden.py"
+: "${COMPILER_DIR:?export COMPILER_DIR to linx toolchain bin}"
+: "${GFRUN:?export GFRUN to the gfrun binary path}"
+
+ROOT="$(echo "$GUARD_ROOT" | sed -E 's@(.*)/benchmark/one-level-arch/test/.*@\1@')"
+ELF_DIR="$ROOT/output/tileop-test/$SUB/elf/$SUB"
+
+pass=0; cfail=0; rfail=0; pfail=0; ronly=0
+echo "=== tileop-guard: $SUB (res_check) ==="
+printf '%-28s %-8s %-8s %-10s\n' "case" "compile" "gfrun" "precision"
+printf '%-28s %-8s %-8s %-10s\n' "----" "-------" "-----" "---------"
+
+for src in "$SUBDIR"/src/*.cpp; do
+    [ -e "$src" ] || { echo "(no cases)"; break; }
+    name="$(basename "$src" .cpp)"
+    [ -n "$ONLY" ] && [ "$name" != "$ONLY" ] && continue
+
+    # 干净捕获每个失败 case 的报错点(仿 version-tracking:per-invocation 捕获 + 无断言取尾部兜底),
+    # 落一条不会错位的 ERRSIG token(TAB 分隔:ERRSIG<域内 case><compile|run><首条报错行>) + per-case 落盘。
+    errsig() {  # $1=name $2=phase(compile|run) $3=完整输出
+        local sig; sig="$(printf '%s' "$3" | grep -iE 'ASSERTION FAILED|illegal instruction|Match Instruction Error|Segmentation|Aborted|abort|fatal|error:|fault' | head -1)"
+        [ -z "$sig" ] && sig="$(printf '%s' "$3" | grep -v '^[[:space:]]*$' | tail -1)"
+        printf 'ERRSIG\t%s\t%s\t%s\n' "$1" "$2" "$(printf '%s' "$sig" | tr '\t' ' ' | cut -c1-220)"
+    }
+
+    clog="$(cd "$SUBDIR" && make TESTCASE="$name" 2>&1)"
+    if [ $? -ne 0 ]; then
+        printf '%-28s %-8s %-8s %-10s\n' "$name" "FAIL" "-" "-"
+        echo "$clog" | grep -E 'error:|assert' | head -3 | sed 's/^/    /'
+        mkdir -p "$GUARD_ROOT/compare/$SUB/$name"; printf '%s\n' "$clog" > "$GUARD_ROOT/compare/$SUB/$name/compile.log"
+        errsig "$name" compile "$clog"
+        cfail=$((cfail+1)); continue
+    fi
+
+    chk="$GUARD_ROOT/compare/$SUB/$name"
+    mkdir -p "$chk"
+    python3 "$GOLDEN" gen "$name" "$chk" >/dev/null 2>&1
+    genrc=$?   # 0 = registered golden; 3 = not registered (run-only)
+
+    elf="$ELF_DIR/$name.elf"
+    rlog="$(timeout 120 "$GFRUN" -f "$elf" 2>&1)"
+    if ! echo "$rlog" | grep -q "Reach the End of Benchmark"; then
+        printf '%-28s %-8s %-8s %-10s\n' "$name" "ok" "FAIL" "-"
+        echo "$rlog" | grep -iE 'assert|error|abort|fault|fatal' | head -3 | sed 's/^/    /'
+        printf '%s\n' "$rlog" > "$chk/gfrun.log"
+        errsig "$name" run "$rlog"
+        rfail=$((rfail+1)); continue
+    fi
+
+    if [ "$genrc" -eq 3 ]; then
+        printf '%-28s %-8s %-8s %-10s\n' "$name" "ok" "ok" "run-only"
+        ronly=$((ronly+1)); continue
+    fi
+
+    cmsg="$(python3 "$GOLDEN" check "$name" "$chk" 2>&1)"
+    if [ $? -eq 0 ]; then
+        printf '%-28s %-8s %-8s %-10s\n' "$name" "ok" "ok" "PASS"
+        pass=$((pass+1))
+    else
+        printf '%-28s %-8s %-8s %-10s\n' "$name" "ok" "ok" "MISMATCH"
+        echo "$cmsg" | head -2 | sed 's/^/    /'
+        pfail=$((pfail+1))
+    fi
+done
+
+echo "----"
+echo "pass=$pass  compile-fail=$cfail  run-fail=$rfail  precision-fail=$pfail  run-only=$ronly"

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/Makefile
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/Makefile
@@ -1,0 +1,3 @@
+SRC_FILE = src/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)/$(TESTCASE).elf
+include ../Makefile.common

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci.cpp
@@ -1,0 +1,29 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TCI (SFU irregular/initialization) — contiguous integer
+// sequence generation ("create index" / vci).
+// Source: docs/tileop-usage/irregular-and-complex/initialization/TCI.md — FULL
+//   signature + example given:
+//     template <is_tile_data_v tile_shape, typename T, int descending=0>
+//     void TCI(tile_shape &dst, T s);
+//   Example: TileT = Tile<Vec,int32_t,1,64>; TCI<TileT,int32_t,0>(dst, 0); TSTORE.
+//   Semantics (doc prose): one row, ValidRow==1; ascending col k = start+k,
+//   descending = start-k; dtype in {S32,S16,U32,U16}.
+// Precision: res_check. TCI takes NO input tile (self-generates), so golden.py
+//   gen is a no-op; the numpy oracle recomputes the iota independently.
+constexpr int GN = 64;                 // 1x64 int32 == 256 B (doc example shape)
+static int32_t out[GN];
+int main() {
+    using TileT = vtile_t<int32_t, 1, GN>;
+    iter_t<int32_t, 1, GN> gO(out);
+    auto gO0 = gO(0, 0);
+    TileT t;
+    BENCHSTART;
+    TCI<TileT, int32_t, 0>(t, 0);      // ascending from 0: col k -> k
+    BENCHEND;
+    TSTORE(gO0, t);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_desc.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_desc.cpp
@@ -1,0 +1,21 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TCI descending variant (create index / vci).
+// Source: TCI.md — the third template parameter `descending` selects direction;
+//   descending col k = start - k. Here start=100 -> 100,99,98,...
+constexpr int GN = 64;
+static int32_t out[GN];
+int main() {
+    using TileT = vtile_t<int32_t, 1, GN>;
+    iter_t<int32_t, 1, GN> gO(out);
+    auto gO0 = gO(0, 0);
+    TileT t;
+    BENCHSTART;
+    TCI<TileT, int32_t, 1>(t, 100);    // descending from 100: col k -> 100-k
+    BENCHEND;
+    TSTORE(gO0, t);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_s16.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_s16.cpp
@@ -1,0 +1,20 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TCI S16 dtype (create index / vci).
+// Source: TCI.md — supported dtypes S32/S16/U32/U16. Ascending from 0.
+constexpr int GN = 64;                 // 1x64 s16 == 128 B
+static int16_t out[GN];
+int main() {
+    using TileT = vtile_t<int16_t, 1, GN>;
+    iter_t<int16_t, 1, GN> gO(out);
+    auto gO0 = gO(0, 0);
+    TileT t;
+    BENCHSTART;
+    TCI<TileT, int16_t, 0>(t, 0);
+    BENCHEND;
+    TSTORE(gO0, t);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_u16.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_u16.cpp
@@ -1,0 +1,20 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TCI U16 dtype (create index / vci).
+// Source: TCI.md — supported dtypes S32/S16/U32/U16. Ascending from 0.
+constexpr int GN = 64;                 // 1x64 u16 == 128 B
+static uint16_t out[GN];
+int main() {
+    using TileT = vtile_t<uint16_t, 1, GN>;
+    iter_t<uint16_t, 1, GN> gO(out);
+    auto gO0 = gO(0, 0);
+    TileT t;
+    BENCHSTART;
+    TCI<TileT, uint16_t, 0>(t, 0);
+    BENCHEND;
+    TSTORE(gO0, t);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_u32.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tci_u32.cpp
@@ -1,0 +1,20 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TCI U32 dtype (create index / vci).
+// Source: TCI.md — supported dtypes S32/S16/U32/U16. Ascending from 0.
+constexpr int GN = 64;                 // 1x64 u32 == 256 B
+static uint32_t out[GN];
+int main() {
+    using TileT = vtile_t<uint32_t, 1, GN>;
+    iter_t<uint32_t, 1, GN> gO(out);
+    auto gO0 = gO(0, 0);
+    TileT t;
+    BENCHSTART;
+    TCI<TileT, uint32_t, 0>(t, 0u);
+    BENCHEND;
+    TSTORE(gO0, t);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolargmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolargmax.cpp
@@ -1,0 +1,32 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TCOLARGMAX — per-column argmax index. Output dtype forced
+// to UINT32 (argReduce). ops-20260904 model writes col reductions into a
+// GENUINE single-row 1 x N tile (index at out[c]); the historical physical
+// M x N + ValidRow=1 workaround read stale bytes. See reducemax_colvec.hpp.
+constexpr int M = 16, N = 16, NE = M * N;
+static float src[NE];
+static uint32_t out[1 * N];
+using OutTile = Tile<Location::Vec, uint32_t, 1, N, BLayout::RowMajor>;
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#else
+    for (int i = 0; i < NE; ++i) src[i] = (float)((i * 37) % 101);
+#endif
+    iter_t<float, M, N> gS(src);
+    global_iterator<gm_t<uint32_t, 1, N>, OutTile> gO(out);
+    auto s0 = gS(0, 0);
+    auto o0 = gO(0, 0);
+    vtile_t<float, M, N> tS;
+    OutTile tD;
+    TLOAD(tS, s0);
+    BENCHSTART;
+    TCOLARGMAX(tD, tS);
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolargmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolargmin.cpp
@@ -1,0 +1,32 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TCOLARGMIN — per-column argmin index. Output dtype forced
+// to UINT32 (argReduce). ops-20260904 model writes col reductions into a
+// GENUINE single-row 1 x N tile (index at out[c]); the historical physical
+// M x N + ValidRow=1 workaround read stale bytes. See reducemax_colvec.hpp.
+constexpr int M = 16, N = 16, NE = M * N;
+static float src[NE];
+static uint32_t out[1 * N];
+using OutTile = Tile<Location::Vec, uint32_t, 1, N, BLayout::RowMajor>;
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#else
+    for (int i = 0; i < NE; ++i) src[i] = (float)((i * 37) % 101);
+#endif
+    iter_t<float, M, N> gS(src);
+    global_iterator<gm_t<uint32_t, 1, N>, OutTile> gO(out);
+    auto s0 = gS(0, 0);
+    auto o0 = gO(0, 0);
+    vtile_t<float, M, N> tS;
+    OutTile tD;
+    TLOAD(tS, s0);
+    BENCHSTART;
+    TCOLARGMIN(tD, tS);
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpand.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpand.cpp
@@ -1,0 +1,33 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TCOLEXPAND — copy-expand from a per-column broadcast source.
+// v0.58 contract (recovered from header + emulator + ValidateReduceAndExpandTepl):
+//   TCOLEXPAND(dst, src): 广播源为 1 x N 行（validRow=1, validCol=N）,dst[i,j]=src[0,j] 全行广播。
+//   **2026-09-08 对齐文档（model 49547742）**: 源改用真 1 x N（`Tile<Vec,float,1,N,RowMajor>`）与
+//   TCOLEXPAND.md 示例一致。spec TCOLEXPAND.asl 只要求源逻辑 ValidRow==1/ValidCol==dst、物理由 layout 派生,
+//   真 1 x N 合法(实测编译+跑通+全 M 行正确广播)。旧注释"模型只填 row0、退化 expand"已过时(模型已修)。
+constexpr int M = 16, N = 16;
+using SrcTile = vtile_t<float, 1, N>;                 // GENUINE 1 x N broadcast row
+static float src[N];
+static float out[M * N];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#endif
+    for (int i = 0; i < N; ++i) if (src[i] == 0.0f) src[i] = (float)(i + 1) * 0.25f;
+    iter_t<float, 1, N> gS(src);
+    iter_t<float, M, N> gO(out);
+    auto s0 = gS(0, 0);
+    auto o0 = gO(0, 0);
+    SrcTile tS;
+    vtile_t<float, M, N> tD;
+    TLOAD(tS, s0);
+    BENCHSTART;
+    TCOLEXPAND(tD, tS);
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandadd.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandadd.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDADD (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpandadd.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDADD(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpanddiv.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpanddiv.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDDIV (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpanddiv.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDDIV(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandexpdif.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandexpdif.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDEXPDIF (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpandexpdif.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDEXPDIF(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandmax.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDMAX (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpandmax.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDMAX(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandmin.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDMIN (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpandmin.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDMIN(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandmul.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandmul.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDMUL (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpandmul.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDMUL(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandsub.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolexpandsub.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLEXPANDSUB (SFU expand-arith, col broadcast 1×N).
+// Semantics (docs/intrinsics/tcolexpandsub.md): dst[i,j] = f(src0[i,j], src1[0,j]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_COLEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TCOLEXPANDSUB(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolmax.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLMAX (SFU reduce, col-reduce over rows).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid 1xN
+// at out[0*N+c]. Precision: res_check, independent numpy golden.
+GUARD_COLREDUCE(float, 16, 16, [](auto& d, auto& s){ TCOLMAX(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolmax_boxcol.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolmax_boxcol.cpp
@@ -1,0 +1,36 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// 场景(新 API 问题): TSTORE 的源 tile = colReduce 的直接输出, 该 tile valid col < physical col
+// (列 boxed, 如 physical 64 / valid 40), 直接 TSTORE 它, 中间不插任何 elementwise op
+// (不经 TCVT/TABS/TSEL/COPY)。涉及列归约族 TCOLMAX/SUM/MIN/PROD/COL{ARG}MAX/MIN。
+//
+// 约束: TCOLMAX API static_assert(template_asm.hpp:13769) 要求 dst.Cols==src.Cols 且
+// dst.ValidCol==src.ValidCol, 故源与目的同为 physical 64 / valid 40。
+// 现象: 编译通过; gfrun 直接 TSTORE 该 boxed-col colReduce 输出时崩:
+//   ASSERTION: IsLegalLocalTileDescriptor(srcs[1]) "Local TSTORE requires one legal source Tile descriptor"
+// 对照(已验证): 非 boxed(64/64) 直接 TSTORE PASS; boxed 输出插 TABS 也崩(TABS 亦拒该 boxed-col 源)。
+// run-fail witness(崩在 TSTORE, 无可校输出)。
+constexpr int M = 16, PN = 64, VN = 40;   // physical col 64, valid col 40 (boxed)
+static float a[M * PN], c[1 * PN];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", a, sizeof(a));
+#else
+    for (int i = 0; i < M * PN; ++i) a[i] = (float)(i % 97) * 0.5f;
+#endif
+    using SrcTile = Tile<Location::Vec, float, M, PN, BLayout::RowMajor, M, VN>;  // 物理 M×64 valid M×40
+    using OutTile = Tile<Location::Vec, float, 1, PN, BLayout::RowMajor, 1, VN>;  // 物理 1×64 valid 1×40 (boxed)
+    iter_t<float, M, PN> gA(a);
+    global_iterator<gm_t<float, 1, PN>, OutTile> gC(c);
+    auto a0 = gA(0, 0);
+    auto c0 = gC(0, 0);
+    SrcTile tA;
+    OutTile tC;
+    TLOAD(tA, a0);
+    TCOLMAX(tC, tA);          // colReduce 直接输出 (boxed col: valid 40 < physical 64)
+    TSTORE(c0, tC);           // 直接 TSTORE, 无中间 elementwise op → gfrun 崩
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", c, sizeof(c));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolmin.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLMIN (SFU reduce, col-reduce over rows).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid 1xN
+// at out[0*N+c]. Precision: res_check, independent numpy golden.
+GUARD_COLREDUCE(float, 16, 16, [](auto& d, auto& s){ TCOLMIN(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolprod.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolprod.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLPROD (SFU reduce, col-reduce over rows).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid 1xN
+// at out[0*N+c]. Precision: res_check, independent numpy golden.
+GUARD_COLREDUCE(float, 16, 16, [](auto& d, auto& s){ TCOLPROD(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolsum.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tcolsum.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCOLSUM (SFU reduce, col-reduce over rows).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid 1xN
+// at out[0*N+c]. Precision: res_check, independent numpy golden.
+GUARD_COLREDUCE(float, 16, 16, [](auto& d, auto& s){ TCOLSUM(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/texp.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/texp.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TEXP (SFU transcendental, elementwise exp).
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) unary inferred). Precision:
+// res_check, independent numpy golden = exp(x) with SFU relative tolerance.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TEXP(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tgather.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tgather.cpp
@@ -1,0 +1,42 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TGATHER (SFU irregular-and-complex, layout).
+// Authoritative semantics (pto-spec normative ASL, irregular-and-complex/layout):
+//   "Gather values from source rows selected independently at each destination
+//   coordinate." source0=value source, source1=per-coordinate ROW-index source.
+//   -> dst[r,c] = value[idx[r,c], c]  (the index picks the ROW; the column stays).
+//   Index dtype ∈ {S16,U16,S32,U32,S64,U64}; signature TGATHER(dst, value, index)
+//   matches docs/tileop-usage engines.md 3-operand form.
+// Precision: res_check READY golden — TGATHER currently run-fails (model gap);
+//   when the model implements it, check_tgather auto-validates.
+constexpr int M = 16, N = 16, NE = M * N;
+static float a[NE], c[NE];
+static int32_t idx[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", a, sizeof(a));
+    guard_read_bin(CHK_DIR "/in_idx.bin", idx, sizeof(idx));
+#else
+    // spec: row index < source ValidRow(M)（TGATHER.asl）。每坐标取 [0,M) 的行号。
+    gfill_seq(a, NE);
+    for (int r = 0; r < M; ++r) for (int cc = 0; cc < N; ++cc) idx[r * N + cc] = (7 * r + 3 * cc) % M;
+#endif
+    gzero(c, NE);
+    iter_t<float, M, N> gA((float *)a), gC(c);
+    iter_t<int32_t, M, N> gI(idx);
+    auto gA0 = gA(0, 0);
+    auto gI0 = gI(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<float, M, N> tA, tC;
+    vtile_t<int32_t, M, N> tI;
+    TLOAD(tA, gA0);
+    TLOAD(tI, gI0);
+    BENCHSTART;
+    TGATHER(tC, tA, tI);
+    BENCHEND;
+    TSTORE(gC0, tC);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", c, sizeof(c));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tgpr2t.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tgpr2t.cpp
@@ -1,0 +1,21 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TGPR2T (SFU/TEPL layout, PTO 0.58.5) — re-encode four
+// 64-bit GPR predicate plane carriers into a U8 CUBE tile.
+// Source: layout-and-rearrangement/layout/TGPR2T.md (v0.58.5).
+// Precision: res_check, *sanity* config (no pto-spec ASL: spec still v0.58.4).
+// All-zero predicate planes -> all-zero U8 output (zero-in -> zero-out repack).
+// dst must be CUBE_M32 32x4 or CUBE_M16 16x8 (static_assert). Golden = zeros.
+constexpr int M = 32, N = 4, NE = M * N;
+static uint8_t gout[NE];
+int main() {
+    using T = VecTileM32<uint8_t, M, N>;
+    T dst;
+    global_tensor<uint8_t, RowMajor<M, N>> gD(gout);
+    BENCHSTART;
+    TGPR2T(dst, 0ull, 0ull, 0ull, 0ull);
+    BENCHEND;
+    TSTORE_CUBE(gD, dst);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tlog.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tlog.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TLOG (SFU transcendental, elementwise natural log).
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) unary inferred). Precision:
+// res_check, independent numpy golden = log(x), positive domain, SFU tolerance.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TLOG(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tpack.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tpack.cpp
@@ -1,0 +1,26 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TPACK (SFU/TEPL layout, PTO 0.58.5) — pack two low-order
+// byte fields of two U32 CUBE words into one U32; unselected high bits zero.
+// Source: layout-and-rearrangement/layout/TPACK.md (v0.58.5).
+// Precision: res_check. Golden pins pto-spec rearrangement.asl:296 (logical,
+// element-wise): dst = (src0 & mask(w0)) | ((src1 & mask(w1)) << 8*w0).
+// control[7:0]=src0 field width, control[15:8]=src1 width (0x0202 -> 2B each).
+constexpr int M = 32, N = 32, NE = M * N;
+static uint32_t ga[NE], gb[NE], gout[NE];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ga, sizeof(ga));
+    guard_read_bin(CHK_DIR "/in_b.bin", gb, sizeof(gb));
+    using T = VecTileM32<uint32_t, M, N>;
+    T src0, src1, dst;
+    global_tensor<uint32_t, RowMajor<M, N>> gA(ga), gB(gb), gD(gout);
+    TLOAD_CUBE(src0, gA);
+    TLOAD_CUBE(src1, gB);
+    const uint64_t control = 0x0202;   // w0=2, w1=2
+    BENCHSTART;
+    TPACK(dst, src0, src1, control);
+    BENCHEND;
+    TSTORE_CUBE(gD, dst);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tpermute.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tpermute.cpp
@@ -1,0 +1,31 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TPERMUTE (SFU/TEPL layout, PTO 0.58.5) — byte-select from
+// two CUBE sources via a U8 index tile; lookup restarts per 128-byte CELL.
+// Source: layout-and-rearrangement/layout/TPERMUTE.md (v0.58.5).
+// Precision: res_check, *identity* config. pto-spec rearrangement.asl:177 reads
+// physical cell bytes; a full permute golden needs the CUBE fractal layout model.
+// Here index byte j = j mod 4 (M32 row_bytes=4) -> each dst byte reads src0's own
+// byte within its word -> dst == src0 (layout-invariant). Golden = src0 (in_a).
+constexpr int M = 32, N = 32, NE = M * N;
+static uint32_t ga[NE], gb[NE], gout[NE];
+static uint8_t  gidx[NE * 4];               // one U8 index per dst byte (32x128)
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ga, sizeof(ga));
+    guard_read_bin(CHK_DIR "/in_b.bin", gb, sizeof(gb));
+    guard_read_bin(CHK_DIR "/in_idx.bin", gidx, sizeof(gidx));
+    using T = VecTileM32<uint32_t, M, N>;
+    using I = VecTileM32<uint8_t, M, N * 4>;
+    T src0, src1, dst; I indices;
+    global_tensor<uint32_t, RowMajor<M, N>> gA(ga), gB(gb), gD(gout);
+    global_tensor<uint8_t, RowMajor<M, N * 4>> gI(gidx);
+    TLOAD_CUBE(src0, gA);
+    TLOAD_CUBE(src1, gB);
+    TLOAD_CUBE(indices, gI);
+    BENCHSTART;
+    TPERMUTE(dst, src0, src1, indices);
+    BENCHEND;
+    TSTORE_CUBE(gD, dst);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trecip.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trecip.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TRECIP (SFU transcendental, elementwise reciprocal).
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) unary inferred). Precision:
+// res_check, independent numpy golden = 1/x, nonzero domain, SFU tolerance.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TRECIP(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowargmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowargmax.cpp
@@ -1,0 +1,35 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TROWARGMAX — per-row argmax index.
+// v0.58: TROWARGMAX(dst, src). The model forces the output dtype to UINT32
+// (argReduce), so a float dst is rejected ("typed Local TSTORE source dtype
+// must match the block dtype"). ops-20260904 TileOP-API requires the row-reduce
+// dst to be a GENUINE single-column tile (ValidCol==1 && Cols==1); index at
+// out[r] of an M x 1 tile. docs 早期无签名/dtype（现 per-op 文档已补）; recovered from the
+// header static_assert + gfrun contract. Precision: res_check.
+constexpr int M = 16, N = 16, NE = M * N;
+static float src[NE];
+static uint32_t out[M * 1];
+using OutTile = Tile<Location::Vec, uint32_t, M, 1, BLayout::RowMajor, M, 1>;
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#else
+    for (int i = 0; i < NE; ++i) src[i] = (float)((i * 37) % 101);
+#endif
+    iter_t<float, M, N> gS(src);
+    global_iterator<gm_t<uint32_t, M, 1>, OutTile> gO(out);
+    auto s0 = gS(0, 0);
+    auto o0 = gO(0, 0);
+    vtile_t<float, M, N> tS;
+    OutTile tD;
+    TLOAD(tS, s0);
+    BENCHSTART;
+    TROWARGMAX(tD, tS);
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowargmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowargmin.cpp
@@ -1,0 +1,32 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TROWARGMIN — per-row argmin index. Output dtype forced to
+// UINT32 (argReduce). ops-20260904 TileOP-API requires a GENUINE single-column
+// dst (ValidCol==1 && Cols==1); index at out[r] of an M x 1 tile.
+// See trowargmax.cpp for the full contract note. Precision: res_check.
+constexpr int M = 16, N = 16, NE = M * N;
+static float src[NE];
+static uint32_t out[M * 1];
+using OutTile = Tile<Location::Vec, uint32_t, M, 1, BLayout::RowMajor, M, 1>;
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#else
+    for (int i = 0; i < NE; ++i) src[i] = (float)((i * 37) % 101);
+#endif
+    iter_t<float, M, N> gS(src);
+    global_iterator<gm_t<uint32_t, M, 1>, OutTile> gO(out);
+    auto s0 = gS(0, 0);
+    auto o0 = gO(0, 0);
+    vtile_t<float, M, N> tS;
+    OutTile tD;
+    TLOAD(tS, s0);
+    BENCHSTART;
+    TROWARGMIN(tD, tS);
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpand.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpand.cpp
@@ -1,0 +1,36 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TROWEXPAND — copy-expand from a per-row broadcast source.
+// v0.58 contract (recovered from header + emulator + ValidateReduceAndExpandTepl):
+//   TROWEXPAND(dst, src) requires ONE broadcast source with validRow=M,
+//   validCol=1, physical col=1 (a physical M x 1 column). The emulator computes
+//   dst[i,j]=src[i,0], BUT the fill width equals the source ValidCol (which the
+//   validator pins to 1), so the model only fills column 0 of dst — a degenerate
+//   "expand". So this is 现已注册 golden（copyexpand，PASS）；correct broadcast source
+//   now COMPILES + RUNS (the previous run-fail is fixed), but the model's fill
+//   width is inconsistent with a full M x N broadcast and is not verified here.
+constexpr int M = 16, N = 16, NE = M * N;
+using SrcTile = vtile_t<float, M, 1>;              // physical M x 1 broadcast column
+static float src[M];
+static float out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", src, sizeof(src));
+#endif
+    for (int i = 0; i < M; ++i) if (src[i] == 0.0f) src[i] = (float)(i + 1) * 0.5f;
+    iter_t<float, M, 1> gS(src);
+    iter_t<float, M, N> gO(out);
+    auto s0 = gS(0, 0);
+    auto o0 = gO(0, 0);
+    SrcTile tS;
+    vtile_t<float, M, N> tD;
+    TLOAD(tS, s0);
+    BENCHSTART;
+    TROWEXPAND(tD, tS);
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandadd.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandadd.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDADD (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpandadd.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDADD(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpanddiv.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpanddiv.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDDIV (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpanddiv.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDDIV(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandexpdif.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandexpdif.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDEXPDIF (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpandexpdif.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDEXPDIF(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandmax.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDMAX (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpandmax.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDMAX(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandmin.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDMIN (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpandmin.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDMIN(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandmul.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandmul.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDMUL (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpandmul.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDMUL(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandsub.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowexpandsub.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWEXPANDSUB (SFU expand-arith, row broadcast M×1).
+// Semantics (docs/intrinsics/trowexpandsub.md): dst[i,j] = f(src0[i,j], src1[i,0]);
+// EXPDIF = exp(src0-src1). Precision: res_check, independent numpy golden.
+GUARD_ROWEXPAND(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TROWEXPANDSUB(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowmax.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWMAX (SFU reduce, row-reduce over cols).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid Mx1
+// at out[r*N+0]. Precision: res_check, independent numpy golden.
+GUARD_ROWREDUCE(float, 16, 16, [](auto& d, auto& s){ TROWMAX(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowmin.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWMIN (SFU reduce, row-reduce over cols).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid Mx1
+// at out[r*N+0]. Precision: res_check, independent numpy golden.
+GUARD_ROWREDUCE(float, 16, 16, [](auto& d, auto& s){ TROWMIN(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowprod.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowprod.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWPROD (SFU reduce, row-reduce over cols).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid Mx1
+// at out[r*N+0]. Precision: res_check, independent numpy golden.
+GUARD_ROWREDUCE(float, 16, 16, [](auto& d, auto& s){ TROWPROD(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowsum.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trowsum.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TROWSUM (SFU reduce, row-reduce over cols).
+// Source: per-op 文档（早期 engines.md 无签名/输出形状，现已补）. Output physical MxN, valid Mx1
+// at out[r*N+0]. Precision: res_check, independent numpy golden.
+GUARD_ROWREDUCE(float, 16, 16, [](auto& d, auto& s){ TROWSUM(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trsqrt.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/trsqrt.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TRSQRT (SFU transcendental, elementwise inverse sqrt).
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) unary inferred; fp32-only per
+// reference tree). Precision: res_check, numpy golden = 1/sqrt(x), SFU tolerance.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TRSQRT(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tscatter.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tscatter.cpp
@@ -1,0 +1,42 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TSCATTER (SFU irregular-and-complex, layout).
+// Authoritative semantics (pto-spec normative ASL, irregular-and-complex/layout):
+//   "For source coordinate [r,c], index value k writes the source bits to
+//   destination [k,c]; duplicate destination coordinates are illegal."
+//   -> dst[idx[r,c], c] = src[r,c]  (index picks the ROW; column stays; index must
+//   be injective within each column). Index dtype ∈ {S16,U16,S32,U32,S64,U64};
+//   signature TSCATTER(dst, src, index) matches engines.md 3-operand form.
+// Precision: res_check READY golden — TSCATTER currently run-fails (model gap);
+//   when the model implements it, check_tscatter auto-validates.
+constexpr int M = 16, N = 16, NE = M * N;
+static float a[NE], c[NE];
+static int32_t idx[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", a, sizeof(a));
+    guard_read_bin(CHK_DIR "/in_idx.bin", idx, sizeof(idx));
+#else
+    // spec: row index < ValidRow(M) 且每列单射(TSCATTER.asl)。用逐列 [0,M) 排列。
+    gfill_seq(a, NE);
+    for (int r = 0; r < M; ++r) for (int cc = 0; cc < N; ++cc) idx[r * N + cc] = (r + cc) % M;
+#endif
+    gzero(c, NE);
+    iter_t<float, M, N> gA((float *)a), gC(c);
+    iter_t<int32_t, M, N> gI(idx);
+    auto gA0 = gA(0, 0);
+    auto gI0 = gI(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<float, M, N> tA, tC;
+    vtile_t<int32_t, M, N> tI;
+    TLOAD(tA, gA0);
+    TLOAD(tI, gI0);
+    BENCHSTART;
+    TSCATTER(tC, tA, tI);
+    BENCHEND;
+    TSTORE(gC0, tC);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", c, sizeof(c));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tshuf.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tshuf.cpp
@@ -1,0 +1,27 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TSHUF (SFU/TEPL layout, PTO 0.58.5) — shuffle 32-bit word
+// groups across power-of-two CUBE row segments per GPR control.
+// Source: layout-and-rearrangement/layout/TSHUF.md (v0.58.5).
+// Precision: res_check, *identity* config. pto-spec rearrangement.asl:222 selects a
+// source row per (row,word) from control; a full shuffle golden needs the physical
+// layout model. Here mode=UP(0), controls all 0 (b=0) -> candidate_row == row ->
+// dst == src (layout-invariant). control scalar = 0. Golden = src (in_a).
+constexpr int M = 32, N = 32, NE = M * N;
+static uint32_t ga[NE], gctrl[NE], gout[NE];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ga, sizeof(ga));
+    guard_read_bin(CHK_DIR "/in_ctrl.bin", gctrl, sizeof(gctrl));
+    using T = VecTileM32<uint32_t, M, N>;
+    T src, controls, dst;
+    global_tensor<uint32_t, RowMajor<M, N>> gA(ga), gC(gctrl), gD(gout);
+    TLOAD_CUBE(src, gA);
+    TLOAD_CUBE(controls, gC);
+    const uint64_t control = 0;   // mode=UP, segment_code=0, boundary=SELF
+    BENCHSTART;
+    TSHUF(dst, src, controls, control);
+    BENCHEND;
+    TSTORE_CUBE(gD, dst);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tsqrt.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tsqrt.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSQRT (SFU transcendental, elementwise square root).
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) unary inferred). Precision:
+// res_check, independent numpy golden = sqrt(x), nonneg domain, SFU tolerance.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TSQRT(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/ttri.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/ttri.cpp
@@ -1,0 +1,22 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TTRI — triangular fill. v0.58 header signature is 1-arg
+// (dst only): the op self-generates a triangular pattern into dst (no input
+// tile). docs/tileop-usage 早期无签名（现 per-op 文档已补）; 1-arg form recovered from the
+// header. Semantics (which triangle / fill value) are not pinned by docs, so
+// 现已注册 golden（check_ttri，PASS）.
+constexpr int M = 16, N = 16, NE = M * N;
+static float out[NE];
+int main() {
+    iter_t<float, M, N> gO(out);
+    auto gO0 = gO(0, 0);
+    vtile_t<float, M, N> tD;
+    BENCHSTART;
+    TTRI(tD);
+    BENCHEND;
+    TSTORE(gO0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tunpack.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/sfu/src/tunpack.cpp
@@ -1,0 +1,24 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TUNPACK (SFU/TEPL layout, PTO 0.58.5) — extract one
+// contiguous byte field from each U32 CUBE word, right-align + zero-extend.
+// Source: layout-and-rearrangement/layout/TUNPACK.md (v0.58.5).
+// Precision: res_check. Golden pins pto-spec rearrangement.asl:332 (logical,
+// element-wise): dst = (src >> 8*off) & mask(cnt).
+// control[7:0]=byte offset (0..3), control[15:8]=byte count (1..4), off+cnt<=4.
+constexpr int M = 32, N = 32, NE = M * N;
+static uint32_t ga[NE], gout[NE];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ga, sizeof(ga));
+    using T = VecTileM32<uint32_t, M, N>;
+    T src, dst;
+    global_tensor<uint32_t, RowMajor<M, N>> gA(ga), gD(gout);
+    TLOAD_CUBE(src, gA);
+    const uint64_t control = 0x0201;   // offset=1, count=2
+    BENCHSTART;
+    TUNPACK(dst, src, control);
+    BENCHEND;
+    TSTORE_CUBE(gD, dst);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/Makefile
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/Makefile
@@ -1,0 +1,3 @@
+SRC_FILE = src/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)/$(TESTCASE).elf
+include ../Makefile.common

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/gmov.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/gmov.cpp
@@ -1,0 +1,20 @@
+#include "guard_common.hpp"
+// TileOP-API doc guard: GMOV (TLSU peer movement) — move tile between PEs.
+// Source: docs/tileop-usage/tlsu.md — example given:  GMOV<15>(dst, peer_tid, src);
+// Contract: all four PEs must reach the same dynamic instance; PEMask selects
+//   requesters only. Peer TID carried by B.IOR.
+int main() {
+    constexpr int M = 8, N = 256, NE = M * N;
+    float a[NE], c[NE];
+    gfill_seq(a, NE); gzero(c, NE);
+    iter_t<float, M, N> gA((float *)a), gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<float, M, N> tA, tC;
+    TLOAD(tA, gA0);
+    BENCHSTART;
+    GMOV<15>(tC, /*peer_tid=*/0, tA);
+    BENCHEND;
+    TSTORE(gC0, tC);
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mgather.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mgather.cpp
@@ -1,0 +1,44 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: MGATHER (TLSU memory) — gather from GM by byte offsets.
+// Source: docs/tileop-usage/tlsu/memory/MGATHER.md — FULL signature + example:
+//     template <tile_out, tile_offset, gm_shape, TmaPadValue Pad=Null>
+//     void MGATHER(tile_out &dst, const gm_shape &src, const tile_offset &offset);
+//   Example: GM=global_tensor<float,RowMajor<8,1024>>; dst=Tile<Vec,float,8,32>.
+//   Doc prose: "offset 中的每个元素是相对于 GM base 的字节位移" -> the addressed
+//   element is *(float*)((char*)base + offset[i]); dst collects them.
+// NOTE(doc-gap 已修复, API 0566283): 早期 MGATHER.md 示例把 offset 声明为 Tile<Vec,uint16_t,...>,
+//   与同页 dtype 表(S32/U32/S64/U64)自相矛盾(逐字照抄 gfrun 拒)。现示例已改用
+//   Tile<Vec,uint32_t,...>(MGATHER.md:102),与 dtype 表一致——本 demo 早已用 U32,与修复后文档一致。
+// Non-trivial offsets (a strided permutation over the whole base), so the golden
+// really exercises the gather addressing rather than an identity copy.
+// Precision: res_check; host owns base + offsets; numpy golden = base[off//4].
+constexpr int BM = 8, BN = 1024, BNE = BM * BN;    // base 8x1024 float
+constexpr int OM = 8, ON = 32, ONE = OM * ON;      // offsets / out 8x32
+static float base[BNE], out[ONE];
+static uint32_t off[ONE];                          // U32 byte displacement (dtype table)
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_base.bin", base, sizeof(base));
+    guard_read_bin(CHK_DIR "/in_off.bin", off, sizeof(off));
+#else
+    for (int i = 0; i < BNE; ++i) base[i] = (float)i;
+    for (int i = 0; i < ONE; ++i) off[i] = (uint32_t)(((i * 101 + 7) % BNE) * 4);
+#endif
+    gm_t<float, BM, BN> base_gm(base);
+    iter_t<uint32_t, OM, ON> gOff(off);
+    iter_t<float, OM, ON> gOut(out);
+    auto gOff0 = gOff(0, 0);
+    auto gOut0 = gOut(0, 0);
+    vtile_t<uint32_t, OM, ON> offset;
+    vtile_t<float, OM, ON> dst;
+    TLOAD(offset, gOff0);
+    BENCHSTART;
+    MGATHER(dst, base_gm, offset);
+    BENCHEND;
+    TSTORE(gOut0, dst);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mgather_cas.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mgather_cas.cpp
@@ -1,0 +1,62 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: MGATHER_CAS (TLSU memory) — per-element compare-and-swap.
+// Source: docs/tileop-usage/tlsu/memory/MGATHER_CAS.md — FULL signature + prose.
+//   void MGATHER_CAS(DstTile &observedOld, uint64_t base,
+//                    IndexTile &byteDisplacements, ExpectedTile &expected,
+//                    ReplacementTile &replacement, uint32_t validCol,
+//                    uint32_t validRow = 1);
+//   Doc semantics: addr = base + byteDisplacement[i]. observedOld[i] = *addr
+//   (value read BEFORE the swap, always). If *addr == expected[i] then
+//   *addr = replacement[i], else *addr unchanged.
+// Precision: res_check. base = address of a host-owned backing array; golden
+//   checks BOTH observedOld (out.bin) AND the post-CAS backing (out_mem.bin).
+//   Injective offsets; even lanes HIT (expected==slot) / odd lanes MISS.
+constexpr int BM = 8, BN = 1024, BNE = BM * BN;    // backing 8x1024 float (GM)
+constexpr int OM = 8, ON = 32, ONE = OM * ON;      // old/exp/rep/off 8x32
+static float backing[BNE], expv[ONE], repv[ONE], oldv[ONE];
+static uint32_t off[ONE];
+int main() {
+    // Leader-gate (issue #489 idiom): MGATHER_CAS mutates SHARED GM state and is
+    // NOT idempotent. gfrun runs 4 SPMD PE-threads (PE0..3), all executing this
+    // block against the SAME `backing` base — without a gate the CAS applies 4x,
+    // so observedOld on the 2nd..4th pass reads the already-swapped replacement
+    // (verified via -t2: lane(0,0) old 4.5->-1.0 across 4 executions). The model's
+    // per-execution CAS is correct (old captured before swap); the 4x replay is a
+    // pure SPMD-structuring artifact. Confine the atomic + I/O to leader tid 0;
+    // workers return and park (no output barrier -> no gfrun hang).
+    if (get_thread_idx() != 0) return 0;
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_base.bin", backing, sizeof(backing));
+    guard_read_bin(CHK_DIR "/in_exp.bin", expv, sizeof(expv));
+    guard_read_bin(CHK_DIR "/in_rep.bin", repv, sizeof(repv));
+    guard_read_bin(CHK_DIR "/in_off.bin", off, sizeof(off));
+#else
+    for (int i = 0; i < BNE; ++i) backing[i] = (float)i;
+    for (int i = 0; i < ONE; ++i) {
+        int idx = (i * 101 + 7) % BNE; off[i] = (uint32_t)(idx * 4);
+        repv[i] = (float)(-i - 1);
+        expv[i] = (i & 1) ? backing[idx] + 1000.0f : backing[idx];  // odd miss / even hit
+    }
+#endif
+    iter_t<float, OM, ON> gE(expv), gR(repv), gO(oldv);
+    iter_t<uint32_t, OM, ON> gI(off);
+    auto gE0 = gE(0, 0);
+    auto gR0 = gR(0, 0);
+    auto gO0 = gO(0, 0);
+    auto gI0 = gI(0, 0);
+    vtile_t<float, OM, ON> tOld, tExp, tRep;
+    vtile_t<uint32_t, OM, ON> tIdx;
+    TLOAD(tExp, gE0);
+    TLOAD(tRep, gR0);
+    TLOAD(tIdx, gI0);
+    BENCHSTART;
+    MGATHER_CAS(tOld, (uint64_t)(uintptr_t)backing, tIdx, tExp, tRep, ON, OM);
+    BENCHEND;
+    TSTORE(gO0, tOld);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", oldv, sizeof(oldv));            // observedOld
+    guard_dump_bin(CHK_DIR "/out_mem.bin", backing, sizeof(backing));  // post-CAS GM
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mgather_mask.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mgather_mask.cpp
@@ -1,0 +1,52 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: MGATHER_MASK (TLSU memory) — masked gather from GM.
+// Source: docs/tileop-usage/tlsu/memory/MGATHER_MASK.md — FULL signature+example:
+//     template <tile_out, tile_offset, tile_mask, gm_shape, TmaPadValue Pad=Null>
+//     void MGATHER_MASK(tile_out &dst, const gm_shape &src,
+//                       const tile_offset &offset, const tile_mask &mask);
+//   Doc prose: "只收集谓词恰为 1 的 lane，并用选定的 padding 值填充禁用的 lane" ->
+//   dst[i] = (mask[i]==1) ? base[off[i]//elem] : Pad. Example uses Pad=Zero,
+//   mask = Tile<Vec,uint8_t,...>.
+// NOTE(doc-gap 已修复, API 0566283): 早期示例 offset 用 uint16_t,与 dtype 表(S32/U32/S64/U64)矛盾;
+//   现 MGATHER_MASK.md:108 示例已改 uint32_t。本 demo 早用 U32,与修复后文档一致。Mask 仍 uint8。
+// Precision: res_check; golden = where(mask==1, base[off//4], 0.0).
+constexpr int BM = 8, BN = 1024, BNE = BM * BN;
+constexpr int OM = 8, ON = 32, ONE = OM * ON;
+static float base[BNE], out[ONE];
+static uint32_t off[ONE];
+static uint8_t msk[ONE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_base.bin", base, sizeof(base));
+    guard_read_bin(CHK_DIR "/in_off.bin", off, sizeof(off));
+    guard_read_bin(CHK_DIR "/in_mask.bin", msk, sizeof(msk));
+#else
+    for (int i = 0; i < BNE; ++i) base[i] = (float)i;
+    for (int i = 0; i < ONE; ++i) { off[i] = (uint32_t)(((i * 101 + 7) % BNE) * 4); msk[i] = (uint8_t)(i % 3 ? 1 : 0); }
+#endif
+    using Values = vtile_t<float, OM, ON>;
+    using ByteOffsets = vtile_t<uint32_t, OM, ON>;
+    using Mask = vtile_t<uint8_t, OM, ON>;
+    using GM = gm_t<float, BM, BN>;
+    GM base_gm(base);
+    iter_t<uint32_t, OM, ON> gOff(off);
+    iter_t<uint8_t, OM, ON> gMsk(msk);
+    iter_t<float, OM, ON> gOut(out);
+    auto gOff0 = gOff(0, 0);
+    auto gMsk0 = gMsk(0, 0);
+    auto gOut0 = gOut(0, 0);
+    Values dst;
+    ByteOffsets offset;
+    Mask mask;
+    TLOAD(offset, gOff0);
+    TLOAD(mask, gMsk0);
+    BENCHSTART;
+    MGATHER_MASK<Values, ByteOffsets, Mask, GM, TmaPadValue::Zero>(dst, base_gm, offset, mask);
+    BENCHEND;
+    TSTORE(gOut0, dst);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mscatter.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mscatter.cpp
@@ -1,0 +1,43 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: MSCATTER (TLSU memory) — scatter to GM by byte offsets.
+// Source: docs/tileop-usage/tlsu/memory/MSCATTER.md — FULL signature + example:
+//     template <tile_in, tile_offset, gm_shape>
+//     void MSCATTER(gm_shape &dst, const tile_in &src, const tile_offset &offset);
+//   Doc prose: "offset 中的每个元素是相对于 GM base 的字节位移" -> the addressed
+//   slot base + offset[i] receives src[i]: base[off[i]//elem] = src[i].
+// NOTE(doc-gap 已修复, API 0566283): 同 MGATHER — 早期示例 offset 用 uint16_t 与 dtype 表矛盾;
+//   现 MSCATTER.md:98 示例已改 uint32_t。本 demo 早用 U32,与修复后文档一致。
+// Offsets are an INJECTIVE map (no two lanes hit the same slot), so the scatter
+//   is order-independent and the numpy golden is deterministic.
+// Precision: res_check. Output checked = the base array AFTER the scatter.
+constexpr int BM = 8, BN = 1024, BNE = BM * BN;    // base 8x1024 float
+constexpr int OM = 8, ON = 32, ONE = OM * ON;      // src / offsets 8x32
+static float base[BNE], src[ONE];
+static uint32_t off[ONE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_base.bin", base, sizeof(base));
+    guard_read_bin(CHK_DIR "/in_src.bin", src, sizeof(src));
+    guard_read_bin(CHK_DIR "/in_off.bin", off, sizeof(off));
+#else
+    for (int i = 0; i < BNE; ++i) base[i] = (float)i;
+    for (int i = 0; i < ONE; ++i) { src[i] = (float)(-i - 1); off[i] = (uint32_t)(((i * 101 + 7) % BNE) * 4); }
+#endif
+    gm_t<float, BM, BN> base_gm(base);
+    iter_t<float, OM, ON> gSrc(src);
+    iter_t<uint32_t, OM, ON> gOff(off);
+    auto gSrc0 = gSrc(0, 0);
+    auto gOff0 = gOff(0, 0);
+    vtile_t<float, OM, ON> tSrc;
+    vtile_t<uint32_t, OM, ON> offset;
+    TLOAD(tSrc, gSrc0);
+    TLOAD(offset, gOff0);
+    BENCHSTART;
+    MSCATTER(base_gm, tSrc, offset);
+    BENCHEND;
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", base, sizeof(base));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mscatter_mask.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/mscatter_mask.cpp
@@ -1,0 +1,49 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: MSCATTER_MASK — masked scatter to GM.
+// v0.58 header signature (recovered from jcore/template_asm.hpp):
+//   MSCATTER_MASK(gm_shape &dst, const src&, const offset&, const mask&)
+//   scatters src[i] to base+off[i] where mask[i]==1. Mirrors MGATHER_MASK.
+// STATUS: correct 4-arg call; the emitted BSTART.TLSU MSCATTER.MASK bundle is
+// not assembled by the current backend ("Match Instruction Error!"), same as
+// MGATHER_MASK — a genuine backend gap, now with the correct signature. golden
+// (where(mask==1)) is ready in golden.py once the backend supports the encoding.
+constexpr int BM = 8, BN = 1024, BNE = BM * BN;
+constexpr int OM = 8, ON = 32, ONE = OM * ON;
+static float base[BNE], src[ONE];
+static uint32_t off[ONE];
+static uint8_t msk[ONE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_base.bin", base, sizeof(base));
+    guard_read_bin(CHK_DIR "/in_src.bin", src, sizeof(src));
+    guard_read_bin(CHK_DIR "/in_off.bin", off, sizeof(off));
+    guard_read_bin(CHK_DIR "/in_mask.bin", msk, sizeof(msk));
+#else
+    for (int i = 0; i < BNE; ++i) base[i] = (float)i;
+    for (int i = 0; i < ONE; ++i) { src[i] = -(float)(i + 1); off[i] = (uint32_t)(((i * 101 + 7) % BNE) * 4); msk[i] = (uint8_t)(i % 3 ? 1 : 0); }
+#endif
+    using Src = vtile_t<float, OM, ON>;
+    using ByteOffsets = vtile_t<uint32_t, OM, ON>;
+    using Mask = vtile_t<uint8_t, OM, ON>;
+    gm_t<float, BM, BN> base_gm(base);
+    iter_t<float, OM, ON> gSrc(src);
+    iter_t<uint32_t, OM, ON> gOff(off);
+    iter_t<uint8_t, OM, ON> gMsk(msk);
+    auto gSrc0 = gSrc(0, 0);
+    auto gOff0 = gOff(0, 0);
+    auto gMsk0 = gMsk(0, 0);
+    Src tSrc;
+    ByteOffsets offset;
+    Mask mask;
+    TLOAD(tSrc, gSrc0);
+    TLOAD(offset, gOff0);
+    TLOAD(mask, gMsk0);
+    BENCHSTART;
+    MSCATTER_MASK(base_gm, tSrc, offset, mask);
+    BENCHEND;
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", base, sizeof(base));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/range_assemble.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/range_assemble.cpp
@@ -1,0 +1,24 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: range::assemble — destination-side range carrier over TLOAD.
+// Correct usage per range-modifiers-developer-guide.md: lowercase lifecycle helper
+// (params auto-derived). A standalone single fragment is a complete session ->
+// assemble_init_last (INIT=1, LAST=1). The uppercase range::Assemble<...,INIT=1,
+// LAST=0,...> hand-filled form (session left open) was a demo misuse.
+constexpr int M = 4, N = 8, NE = M * N;
+static float ha[NE], hc[NE];
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+    using Dst = vtile_t<float, M, N>;
+    Dst d;
+    global_tensor<float, RowMajor<M, N>> gm(ha);
+    iter_t<float, M, N> gC(hc);
+    auto gC0 = gC(0, 0);
+    BENCHSTART;
+    auto as = range::assemble_init_last(d, 0);   // lowercase helper, complete session
+    TLOAD(as, gm);
+    BENCHEND;
+    TSTORE(gC0, d);
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/range_subview.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/range_subview.cpp
@@ -1,0 +1,41 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: range::subview — source-side range carrier over TSTORE
+// （低层 subview 路径看护；CUBE 路径由 tpartview_subview.cpp 另行看护）。
+//
+// 写法本身合规：range-modifiers.md 状态清单列 "Implemented: Local source Subview
+// over TSTORE"，developer-guide 的 store_subview 示例即 `TSTORE(gm, range::subview(t))`。
+//
+// 但这是 **fail-closed witness**（API↔spec 缺口，非模型 bug、非写法错）：
+//  - API：`range::subview`+TSTORE 路径带 requires(!IsCubeLayout)，只对 **RowMajor**
+//    parent 发 B.SUBVIEW（本 demo 即此形式，Vec/RowMajor parent）。
+//  - 模型：`subview-descriptor.asl::BundleCubeSubviewDescriptorOf` 要求 parent
+//    location==Matrix && CUBE layout，非 CUBE 一律 Fault_TileLegality（ASL-correct）。
+//  → RowMajor subview 被模型正确拒（gfrun: illegal TSTORE operand or descriptor
+//    contract）。API 的 CUBE subview binder 尚未实现（range-modifiers.md line 118-123
+//    自述 "region producer ... intentionally limited to RowMajor+NoneBox ... until the
+//    Cube binder/CELL ordering path is implemented and validated"）。
+//  归属 = Linx-TileOP-API 未实现 cube subview；run-fail 作缺口 witness，无 golden。
+constexpr int M = 4, N = 8, NE = M * N;
+static float ha[NE], hc[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+#else
+    gfill_seq(ha, NE);
+#endif
+    using Src = vtile_t<float, M, N>;
+    Src s;
+    iter_t<float, M, N> gA(ha);
+    auto gA0 = gA(0, 0);
+    global_tensor<float, RowMajor<M, N>> gm(hc);
+    TLOAD(s, gA0);
+    BENCHSTART;
+    auto sv = range::subview(s);       // lowercase helper
+    TSTORE(gm, sv);
+    BENCHEND;
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/region_tilearray.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/region_tilearray.cpp
@@ -1,0 +1,56 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+#include <utility>
+// TileOP-API doc guard: TileArray region API — TileArray / TASSEMBLY (+ TCVT
+// slot producer). Source: docs/tileop-usage/range-modifiers.md "TileArray region
+// API" (NEW on remote branch linx, commit fa24eae).
+// NOTE(doc-gap 部分已修复, API 0566283): 文档示例已自洽(变量名统一 source_tile、TCVT 目的取
+//   TileArrayOutputRef 按值);运行期仍 run-fail 但报错已变——当前模型(49547742)为
+//   `illegal B.ASSEMBLE generation or descriptor contract`(非旧 `raw tile spill`)。已单独钉证:
+//   发射侧合规(carrier 按 parent 分配+B.ASSEMBLE offset/coverage 全对+INIT=parent 规范),多 writer
+//   (parent>writer)组装被 `PrepareLocalAssemble` 拒——证据指向模型侧,owner 待官方裁决;详见
+//   issues/ISSUE_ops-20260904_20260908_DRAFT-gfrun-region-tilearray.md。以下为早期(旧文档/旧模型)记录存档:
+//   (1) `TCVT(destinations[0][2], source_tile)` 用临时量,但 region TCVT 签名是
+//       `TCVT(TileArrayOutputRef& dst, In& src)`(非 const 左值引用),须先绑具名左值;
+//   (2) 示例源变量名 source(=TPARTVIEW 视图)与 TCVT 用的 source_tile 不一致;实测
+//       用 TPARTVIEW 的父 strided 子视图作源 → gfrun `raw tile spill source does not
+//       fit the carrier shape`。正解:源须为独立紧凑 Fragment Tile。
+//   (3) 即便改用独立紧凑 Fragment 作源,gfrun 仍断言 `RawTileSourceFits(source,
+//       shape) && "raw tile spill source does not fit the carrier shape"`——region
+//       producer 写入 carrier slot 的形状契约与紧凑 Fragment 不符。结合文档自身
+//       "until the ... path is implemented and validated" 告警,且该特性是远程
+//       linx 顶端 commit,判定:**新 API 在当前 env_test 模型上尚不可运行(run-fail)**。
+// 本 demo 保留以看护该新接口:编译需绕过文档示例的左值绑定缺口,运行期受阻于模型
+// 未就绪。待模型侧补齐后再验证组装布局。
+constexpr int PM = 32, PN = 64, FN = 16, NF = PN / FN;   // 4 fragments of 32x16
+static float gin[PM * PN], gout[PM * PN];                // gin = 4 contiguous 32x16 blocks
+int main() {
+    guard_read_bin(CHK_DIR "/in_a.bin", gin, sizeof(gin));
+    using Parent   = Tile<Location::Vec, float, PM, PN, BLayout::RowMajor>;
+    using Fragment = Tile<Location::Vec, float, PM, FN, BLayout::RowMajor>;
+
+    region::TileArray<Fragment, 1, NF> dst;
+    Fragment src0, src1, src2, src3;
+    iter_t<float, PM, FN> g0(gin + 0 * PM * FN);
+    iter_t<float, PM, FN> g1(gin + 1 * PM * FN);
+    iter_t<float, PM, FN> g2(gin + 2 * PM * FN);
+    iter_t<float, PM, FN> g3(gin + 3 * PM * FN);
+    auto g0v = g0(0, 0); auto g1v = g1(0, 0);
+    auto g2v = g2(0, 0); auto g3v = g3(0, 0);
+    TLOAD(src0, g0v); TLOAD(src1, g1v);
+    TLOAD(src2, g2v); TLOAD(src3, g3v);
+
+    auto d0 = dst[0][0]; auto d1 = dst[0][1];
+    auto d2 = dst[0][2]; auto d3 = dst[0][3];
+    BENCHSTART;
+    TCVT(d0, src0); TCVT(d1, src1);
+    TCVT(d2, src2); TCVT(d3, src3);
+    Parent result = TASSEMBLY<Parent>(std::move(dst));
+    BENCHEND;
+
+    iter_t<float, PM, PN> go(gout);
+    auto go0 = go(0, 0);
+    TSTORE(go0, result);
+    guard_dump_bin(CHK_DIR "/out.bin", gout, sizeof(gout));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tload.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tload.cpp
@@ -1,0 +1,18 @@
+#include "guard_common.hpp"
+// TileOP-API doc guard: TLOAD (TLSU) — GM -> Local tile.
+// Source: docs/tileop-usage/tlsu.md — block layout given; C++ form is
+//   TLOAD(tile, iterator). global_iterator supplies base + row stride.
+int main() {
+    constexpr int M = 16, N = 16, NE = M * N;
+    float a[NE], c[NE];
+    gfill_seq(a, NE); gzero(c, NE);
+    iter_t<float, M, N> gA((float *)a), gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<float, M, N> t;
+    BENCHSTART;
+    TLOAD(t, gA0);
+    BENCHEND;
+    TSTORE(gC0, t);
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tmov.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tmov.cpp
@@ -1,0 +1,19 @@
+#include "guard_common.hpp"
+// TileOP-API doc guard: TMOV (TLSU) — tile-to-tile move (Local).
+// Source: docs/tileop-usage/tlsu.md + engines.md (function 2). No explicit C++
+// signature for the base Local form; `(dst, src)` inferred.
+int main() {
+    constexpr int M = 16, N = 16, NE = M * N;
+    float a[NE], c[NE];
+    gfill_seq(a, NE); gzero(c, NE);
+    iter_t<float, M, N> gA((float *)a), gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<float, M, N> tA, tC;
+    TLOAD(tA, gA0);
+    BENCHSTART;
+    TMOV(tC, tA);
+    BENCHEND;
+    TSTORE(gC0, tC);
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tpartview_subview.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tpartview_subview.cpp
@@ -1,0 +1,41 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TPARTVIEW（推荐高层 B.SUBVIEW 入口）+ region 一元 op。
+// range-modifiers-developer-guide.md：推荐通过 TPARTVIEW / TileArray / TASSEMBLY 描述
+// parent Tile 的分区与组装；range::subview/assemble 仅作底层兼容/测试接口。TPARTVIEW 把
+// 一个 CUBE/Matrix parent 划分为 R×C 个同布局 fragment，槽 SubTileView 被 region 一元 op
+// （TABS，pto_region_unary）消费时发出 `BSTART.TEPL … B.SUBVIEW`（接受 IsCubeLayout fragment）。
+//
+// spec 侧：B.SUBVIEW 只接受 Matrix+CUBE parent（subview-descriptor.asl），故此处用 CUBE parent。
+//
+// 状态 = run-only（能编译 + 跑通，但精度不 golden）：API 自述 region producer 的 CUBE 路径
+// **尚未实现/验证**（range-modifiers.md line 118-123："region producer inline-asm path is
+// intentionally limited to RowMajor+NoneBox ... do not use ... row-wise region producers with
+// Cube fragments until the Cube binder/CELL ordering path is implemented and validated"）。
+// 实测 out == abs(in).T（CUBE cell ordering 未实现的表现），是 API 未完成路径而非规范语义，
+// 按 golden 纪律不焊进 oracle。此 demo 看护"TPARTVIEW+region op 的 cube B.SUBVIEW 能编译+
+// 跑通不被 ASL 拒"，并见证 cube cell-ordering 尚未落地。CUBE binder 实现后可升级为精度 golden。
+constexpr int M = 32, N = 32, NE = M * N;
+static float ha[NE], hc[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", ha, sizeof(ha));
+#else
+    gfill_seq(ha, NE);
+#endif
+    CubeTileM32<float, M, N> parent;                 // Matrix(Left) + CUBE layout
+    global_tensor<float, RowMajor<M, N>> gA(ha);
+    global_tensor<float, RowMajor<M, N>> gm(hc);
+    TLOAD_CUBE(parent, gA);
+    auto tpv = TPARTVIEW<CubeTileM32<float, M, N>, 1, 1>(parent);
+    auto slot = tpv[0][0];                            // SubTileView = 合法 B.SUBVIEW 源
+    CubeAccumulatorM32<float, M, N> out;
+    BENCHSTART;
+    TABS(out, slot);                                 // region unary → emits B.SUBVIEW
+    BENCHEND;
+    TSTORE_CUBE(gm, out);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", hc, sizeof(hc));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tprefetch.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tprefetch.cpp
@@ -1,0 +1,17 @@
+#include "guard_common.hpp"
+// TileOP-API doc guard: TPREFETCH (TLSU) — prefetch GM range, no tile binding.
+// Source: docs/tileop-usage/tlsu.md — FULL signature:
+//   TPREFETCH(src, valid_col, valid_row)
+// LB0/LB1 = valid shape, LB2 = physical row width, B.IOR = base + row stride.
+int main() {
+    constexpr int M = 16, N = 16, NE = M * N;
+    float a[NE];
+    gfill_seq(a, NE);
+    // doc: src is a "static RowMajor global_tensor" (physical row width from
+    // its compile-time column count) -> use gm_t directly, not an iterator view.
+    gm_t<float, M, N> gA((float *)a);
+    BENCHSTART;
+    TPREFETCH(gA, N, M);   // valid_col=N, valid_row=M
+    BENCHEND;
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tstore.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/tlsu/src/tstore.cpp
@@ -1,0 +1,17 @@
+#include "guard_common.hpp"
+// TileOP-API doc guard: TSTORE (TLSU) — Local tile -> GM.
+// Source: docs/tileop-usage/tlsu.md — TSTORE(iterator, tile).
+int main() {
+    constexpr int M = 16, N = 16, NE = M * N;
+    float a[NE], c[NE];
+    gfill_seq(a, NE); gzero(c, NE);
+    iter_t<float, M, N> gA((float *)a), gC(c);
+    auto gA0 = gA(0, 0);
+    auto gC0 = gC(0, 0);
+    vtile_t<float, M, N> t;
+    TLOAD(t, gA0);
+    BENCHSTART;
+    TSTORE(gC0, t);
+    BENCHEND;
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/Makefile
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/Makefile
@@ -1,0 +1,3 @@
+SRC_FILE = src/$(TESTCASE).cpp
+TARGET = $(ELF_HEAD)/$(TESTCASE).elf
+include ../Makefile.common

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tabs.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tabs.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TABS (VEC, elementwise-tile-tile, unary)
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) inferred). Precision: res_check.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TABS(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tadd.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tadd.cpp
@@ -1,0 +1,29 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API doc guard: TADD (VEC, elementwise-tile-tile, binary)
+// Source: docs/tileop-usage/engines.md — VEC | TADD | elementwise-tile-tile.
+// NOTE(doc-gap): engines.md lists the op + class（早期无签名，现 per-op 文档已补签名）for
+// basic arithmetic; the (dst,src0,src1) call shape is inferred from the
+// dst-first convention shown in cmp.md / cube.md.
+//
+// Precision: res_check path. Inputs are host-generated (golden.py gen) and read
+// via read() syscall — device-side fills get mangled by the tile backend, so
+// host owns the inputs. Output is dumped for an independent numpy golden.
+constexpr int GM = 16, GN = 16, GNE = GM * GN;
+static float a[GNE], b[GNE], c[GNE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", a, sizeof(a));
+    guard_read_bin(CHK_DIR "/in_b.bin", b, sizeof(b));
+#else
+    guard_fill_seq_f32(a, GNE, 1.0f, 0.1f);
+    guard_fill_seq_f32(b, GNE, 2.0f, 0.3f);
+#endif
+    BENCHSTART;
+    g_binary<float, GM, GN>(c, a, b, [](auto& d, auto& s0, auto& s1){ TADD(d, s0, s1); });
+    BENCHEND;
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", c, sizeof(c));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tadds.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tadds.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TADDS (VEC, tile-scalar). Source: per-op 文档（早期 engines.md 无签名，现已补）.
+// Precision: res_check, scalar=1.75.
+GUARD_SCALAR(float, 16, 16, 1.75f, [](auto& d, auto& s0, auto& sc){ TADDS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tand.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tand.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TAND (VEC, elementwise-tile-tile, integer binary)
+// Source: per-op 文档（早期 engines.md 无签名/dtype，现已补；int32 chosen）. Precision: res_check.
+GUARD_BINARY(int32_t, 16, 16, [](auto& d, auto& s0, auto& s1){ TAND(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tands.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tands.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TANDS (VEC, tile-scalar, integer). Source: engines.md.
+// Precision: res_check, scalar=5.
+GUARD_SCALAR(int32_t, 16, 16, 5, [](auto& d, auto& s0, auto& sc){ TANDS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tcmp.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tcmp.cpp
@@ -1,0 +1,39 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TCMP — compare producing a PACKED PREDICATE (logical tile).
+// v0.58: TCMP<Mode>(dst, src0, src1). The result is a packed predicate that
+// CANNOT be TSTORE'd directly (gfrun: "Local TSTORE requires one legal source
+// Tile descriptor"); it must be consumed by TSEL as the mask. Correct
+// end-to-end usage exercised here:
+//   TCMP<GT>(mask, a, b);  TSEL(dst=prior, mask, tru);  store(dst)
+//   => out = where(a > b, tru, prior)
+// cmp.md documents the signature but NOT the predicate-consumption contract
+// (recovered from the header + gfrun contract). Precision: res_check.
+constexpr int M = 16, N = 16, NE = M * N;
+static int32_t A[NE], B[NE], prior[NE], tru[NE], out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", A, sizeof(A));
+    guard_read_bin(CHK_DIR "/in_b.bin", B, sizeof(B));
+    guard_read_bin(CHK_DIR "/in_c.bin", prior, sizeof(prior));
+    guard_read_bin(CHK_DIR "/in_d.bin", tru, sizeof(tru));
+#else
+    for (int i = 0; i < NE; ++i) { A[i] = i - 8; B[i] = (i * 3) % 11 - 5; prior[i] = -i - 1; tru[i] = i + 100; }
+#endif
+    iter_t<int32_t, M, N> gA(A), gB(B), gP(prior), gT(tru), gO(out);
+    auto a0 = gA(0, 0), b0 = gB(0, 0), p0 = gP(0, 0), t0 = gT(0, 0), o0 = gO(0, 0);
+    vtile_t<int32_t, M, N> tA, tB, tMask, tD, tTru;
+    TLOAD(tA, a0);
+    TLOAD(tB, b0);
+    TLOAD(tD, p0);         // dst prior = false source (TSEL in-place)
+    TLOAD(tTru, t0);
+    BENCHSTART;
+    TCMP<CmpMode::GT>(tMask, tA, tB);   // predicate
+    TSEL(tD, tMask, tTru);              // dst = mask ? tru : prior
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tcmps.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tcmps.cpp
@@ -1,0 +1,34 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TCMPS — tile-vs-scalar compare producing a packed predicate.
+// v0.58: TCMPS<Mode>(dst, src, scalar). Like TCMP, the result is a predicate
+// that cannot be TSTORE'd directly; it is consumed by TSEL. End-to-end usage:
+//   TCMPS<GT>(mask, a, 0);  TSEL(dst=prior, mask, tru)  => out = where(a>0, tru, prior)
+// cmp.md documents the signature but not the predicate-consumption contract.
+// Precision: res_check.
+constexpr int M = 16, N = 16, NE = M * N;
+static int32_t A[NE], prior[NE], tru[NE], out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", A, sizeof(A));
+    guard_read_bin(CHK_DIR "/in_b.bin", prior, sizeof(prior));
+    guard_read_bin(CHK_DIR "/in_c.bin", tru, sizeof(tru));
+#else
+    for (int i = 0; i < NE; ++i) { A[i] = i - 8; prior[i] = -i - 1; tru[i] = i + 100; }
+#endif
+    iter_t<int32_t, M, N> gA(A), gP(prior), gT(tru), gO(out);
+    auto a0 = gA(0, 0), p0 = gP(0, 0), t0 = gT(0, 0), o0 = gO(0, 0);
+    vtile_t<int32_t, M, N> tA, tMask, tD, tTru;
+    TLOAD(tA, a0);
+    TLOAD(tD, p0);         // dst prior = false source (in-place)
+    TLOAD(tTru, t0);
+    BENCHSTART;
+    TCMPS<CmpMode::GT>(tMask, tA, 0);   // predicate: a > 0
+    TSEL(tD, tMask, tTru);              // dst = (a>0) ? tru : prior
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tcvt.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tcvt.cpp
@@ -1,0 +1,8 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TCVT (VEC, elementwise numeric conversion fp32 -> s32).
+// Source: docs/tileop-usage/reinterpret-tile.md — contrasts TCVT (numeric
+// conversion, emits hardware op) vs reinterpret_tile (bit view). Signature
+// shown there: TCVT(converted, src) with distinct dst dtype.
+// Precision: res_check, host-generated fp32 (both signs, .5 midpoints), golden
+// pins the rounding mode (see golden.py fam='cvt' round=...).
+GUARD_UNARY_CVT(float, int32_t, 16, 16, [](auto& d, auto& s){ TCVT(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tdiv.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tdiv.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TDIV (VEC, elementwise-tile-tile, binary)
+// Source: engines.md (no C++ signature; dst-first inferred). Precision: res_check,
+// host-owned inputs (golden.py), independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TDIV(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tdivs.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tdivs.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TDIVS (VEC, tile-scalar). Source: per-op 文档（早期 engines.md 无签名，现已补）.
+// Precision: res_check, scalar=1.75.
+GUARD_SCALAR(float, 16, 16, 1.75f, [](auto& d, auto& s0, auto& sc){ TDIVS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/texpands.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/texpands.cpp
@@ -1,0 +1,16 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TEXPANDS (VEC, tile-scalar-and-immediate): dst filled with
+// scalar (2 args, no src). Source: engines.md. Precision: res_check, scalar=1.75.
+constexpr int GM = 16, GN = 16;
+static float gC[GM * GN];
+int main() {
+    iter_t<float, GM, GN> gc(gC);
+    auto gc0 = gc(0, 0);
+    vtile_t<float, GM, GN> tC;
+    BENCHSTART;
+    TEXPANDS(tC, 1.75f);
+    BENCHEND;
+    TSTORE(gc0, tC);
+    guard_dump_bin(CHK_DIR "/out.bin", gC, sizeof(gC));
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tfma.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tfma.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TFMA (VEC, ternary a*b+c). Source: per-op 文档（早期 engines.md 无签名，现已补；
+// (dst,a,b,c) inferred). Precision: res_check.
+GUARD_TERNARY(float, 16, 16, [](auto& d, auto& s0, auto& s1, auto& s2){ TFMA(d, s0, s1, s2); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmax.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmax.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TMAX (VEC, elementwise-tile-tile, binary)
+// Source: engines.md (no C++ signature; dst-first inferred). Precision: res_check,
+// host-owned inputs (golden.py), independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TMAX(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmaxs.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmaxs.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TMAXS (VEC, tile-scalar). Source: per-op 文档（早期 engines.md 无签名，现已补）.
+// Precision: res_check, scalar=1.75.
+GUARD_SCALAR(float, 16, 16, 1.75f, [](auto& d, auto& s0, auto& sc){ TMAXS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmin.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmin.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TMIN (VEC, elementwise-tile-tile, binary)
+// Source: engines.md (no C++ signature; dst-first inferred). Precision: res_check,
+// host-owned inputs (golden.py), independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TMIN(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmins.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmins.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TMINS (VEC, tile-scalar). Source: per-op 文档（早期 engines.md 无签名，现已补）.
+// Precision: res_check, scalar=1.75.
+GUARD_SCALAR(float, 16, 16, 1.75f, [](auto& d, auto& s0, auto& sc){ TMINS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmul.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmul.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TMUL (VEC, elementwise-tile-tile, binary)
+// Source: engines.md (no C++ signature; dst-first inferred). Precision: res_check,
+// host-owned inputs (golden.py), independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TMUL(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmuls.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tmuls.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TMULS (VEC, tile-scalar). Source: per-op 文档（早期 engines.md 无签名，现已补）.
+// Precision: res_check, scalar=1.75.
+GUARD_SCALAR(float, 16, 16, 1.75f, [](auto& d, auto& s0, auto& sc){ TMULS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tneg.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tneg.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TNEG (VEC, elementwise-tile-tile, unary)
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) inferred). Precision: res_check.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TNEG(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tnot.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tnot.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TNOT (VEC, elementwise-tile-tile, unary integer).
+// Source: engines.md. Precision: res_check.
+GUARD_UNARY(int32_t, 16, 16, [](auto& d, auto& s){ TNOT(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tor.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tor.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TOR (VEC, elementwise-tile-tile, integer binary)
+// Source: per-op 文档（早期 engines.md 无签名/dtype，现已补；int32 chosen）. Precision: res_check.
+GUARD_BINARY(int32_t, 16, 16, [](auto& d, auto& s0, auto& s1){ TOR(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tors.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tors.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TORS (VEC, tile-scalar, integer). Source: engines.md.
+// Precision: res_check, scalar=5.
+GUARD_SCALAR(int32_t, 16, 16, 5, [](auto& d, auto& s0, auto& sc){ TORS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/trelu.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/trelu.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TRELU (VEC, elementwise-tile-tile, unary)
+// Source: per-op 文档（早期 engines.md 无签名，现已补；(dst,src) inferred). Precision: res_check.
+GUARD_UNARY(float, 16, 16, [](auto& d, auto& s){ TRELU(d, s); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/trem.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/trem.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TREM (VEC, elementwise-tile-tile, integer binary)
+// Source: per-op 文档（早期 engines.md 无签名/dtype，现已补；int32 chosen）. Precision: res_check.
+GUARD_BINARY(int32_t, 16, 16, [](auto& d, auto& s0, auto& s1){ TREM(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/trems.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/trems.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TREMS (VEC, tile-scalar, integer). Source: engines.md.
+// Precision: res_check, scalar=5.
+GUARD_SCALAR(int32_t, 16, 16, 5, [](auto& d, auto& s0, auto& sc){ TREMS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsel.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsel.cpp
@@ -1,0 +1,38 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TSEL — masked select, IN-PLACE on dst.
+// v0.58: TSEL(dst, mask, true_src) with dst[i] = (mask[i]) ? true_src[i] : dst_prior[i].
+// The mask MUST be a packed predicate (logical tile) — gfrun rejects a plain
+// data tile ("select first B.IOT requires mask then true/source Tile"). The only
+// producer of a predicate is TCMP/TCMPS, so a correct TSEL demo chains them:
+//   TCMP<LT>(mask, a, b);  TSEL(dst=prior, mask, tru)  => out = where(a<b, tru, prior)
+// 早期 engines.md 无签名/语义（现 per-op 文档已补）; recovered from the header +
+// gfrun contract. Precision: res_check.
+constexpr int M = 16, N = 16, NE = M * N;
+static int32_t A[NE], B[NE], prior[NE], tru[NE], out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", A, sizeof(A));
+    guard_read_bin(CHK_DIR "/in_b.bin", B, sizeof(B));
+    guard_read_bin(CHK_DIR "/in_c.bin", prior, sizeof(prior));
+    guard_read_bin(CHK_DIR "/in_d.bin", tru, sizeof(tru));
+#else
+    for (int i = 0; i < NE; ++i) { A[i] = i - 8; B[i] = (i * 3) % 11 - 5; prior[i] = -i - 1; tru[i] = i + 100; }
+#endif
+    iter_t<int32_t, M, N> gA(A), gB(B), gP(prior), gT(tru), gO(out);
+    auto a0 = gA(0, 0), b0 = gB(0, 0), p0 = gP(0, 0), t0 = gT(0, 0), o0 = gO(0, 0);
+    vtile_t<int32_t, M, N> tA, tB, tMask, tD, tTru;
+    TLOAD(tA, a0);
+    TLOAD(tB, b0);
+    TLOAD(tD, p0);         // dst prior = false source (in-place)
+    TLOAD(tTru, t0);
+    BENCHSTART;
+    TCMP<CmpMode::LT>(tMask, tA, tB);   // predicate feeding TSEL
+    TSEL(tD, tMask, tTru);              // dst = mask ? tru : prior
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsels.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsels.cpp
@@ -1,0 +1,37 @@
+#include "guard_common.hpp"
+#include "guard_io.h"
+// TileOP-API guard: TSELS — masked select between a tile source and a scalar.
+// v0.58: TSELS(dst, mask, scalar, src1). gfrun contract: srcs[1] is a logical
+// predicate (mask), srcs[2] a data source; dst is a fresh output (not in-place).
+// So the mask must come from TCMP. End-to-end:
+//   TCMP<GT>(mask, a, b);  TSELS(dst, mask, SVAL, src)  => out = where(a>b, src, SVAL)
+// (polarity confirmed by the res_check golden). docs 早期无签名（现 per-op 文档已补）; the
+// scalar-in-the-middle 4-arg form + predicate contract are recovered from the
+// header + gfrun. Precision: res_check.
+constexpr int M = 16, N = 16, NE = M * N;
+constexpr int32_t SVAL = 777;
+static int32_t A[NE], B[NE], src[NE], out[NE];
+int main() {
+#ifdef RES_CHECK
+    guard_read_bin(CHK_DIR "/in_a.bin", A, sizeof(A));
+    guard_read_bin(CHK_DIR "/in_b.bin", B, sizeof(B));
+    guard_read_bin(CHK_DIR "/in_c.bin", src, sizeof(src));
+#else
+    for (int i = 0; i < NE; ++i) { A[i] = i - 8; B[i] = (i * 3) % 11 - 5; src[i] = i + 100; }
+#endif
+    iter_t<int32_t, M, N> gA(A), gB(B), gS(src), gO(out);
+    auto a0 = gA(0, 0), b0 = gB(0, 0), s0 = gS(0, 0), o0 = gO(0, 0);
+    vtile_t<int32_t, M, N> tA, tB, tMask, tSrc, tD;
+    TLOAD(tA, a0);
+    TLOAD(tB, b0);
+    TLOAD(tSrc, s0);
+    BENCHSTART;
+    TCMP<CmpMode::GT>(tMask, tA, tB);       // predicate: a > b
+    TSELS(tD, tMask, SVAL, tSrc);           // dst = mask ? src : SVAL
+    BENCHEND;
+    TSTORE(o0, tD);
+#ifdef RES_CHECK
+    guard_dump_bin(CHK_DIR "/out.bin", out, sizeof(out));
+#endif
+    return 0;
+}

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshl.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshl.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSHL (VEC, elementwise-tile-tile, integer binary)
+// Source: per-op 文档（早期 engines.md 无签名/dtype，现已补；int32 chosen）. Precision: res_check.
+GUARD_BINARY(int32_t, 16, 16, [](auto& d, auto& s0, auto& s1){ TSHL(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshls.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshls.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSHLS (VEC, tile-scalar, integer). Source: engines.md.
+// Precision: res_check, scalar=5.
+GUARD_SCALAR(int32_t, 16, 16, 5, [](auto& d, auto& s0, auto& sc){ TSHLS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshr.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshr.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSHR (VEC, elementwise-tile-tile, integer binary)
+// Source: per-op 文档（早期 engines.md 无签名/dtype，现已补；int32 chosen）. Precision: res_check.
+GUARD_BINARY(int32_t, 16, 16, [](auto& d, auto& s0, auto& s1){ TSHR(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshrs.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tshrs.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSHRS (VEC, tile-scalar, integer). Source: engines.md.
+// Precision: res_check, scalar=5.
+GUARD_SCALAR(int32_t, 16, 16, 5, [](auto& d, auto& s0, auto& sc){ TSHRS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsub.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsub.cpp
@@ -1,0 +1,5 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSUB (VEC, elementwise-tile-tile, binary)
+// Source: engines.md (no C++ signature; dst-first inferred). Precision: res_check,
+// host-owned inputs (golden.py), independent numpy golden.
+GUARD_BINARY(float, 16, 16, [](auto& d, auto& s0, auto& s1){ TSUB(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsubs.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/tsubs.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TSUBS (VEC, tile-scalar). Source: per-op 文档（早期 engines.md 无签名，现已补）.
+// Precision: res_check, scalar=1.75.
+GUARD_SCALAR(float, 16, 16, 1.75f, [](auto& d, auto& s0, auto& sc){ TSUBS(d, s0, sc); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/txor.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/txor.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TXOR (VEC, elementwise-tile-tile, integer binary)
+// Source: per-op 文档（早期 engines.md 无签名/dtype，现已补；int32 chosen）. Precision: res_check.
+GUARD_BINARY(int32_t, 16, 16, [](auto& d, auto& s0, auto& s1){ TXOR(d, s0, s1); })

--- a/benchmark/one-level-arch/test/solution/tileop-test/vec/src/txors.cpp
+++ b/benchmark/one-level-arch/test/solution/tileop-test/vec/src/txors.cpp
@@ -1,0 +1,4 @@
+#include "guard_case.hpp"
+// TileOP-API doc guard: TXORS (VEC, tile-scalar, integer). Source: engines.md.
+// Precision: res_check, scalar=5.
+GUARD_SCALAR(int32_t, 16, 16, 5, [](auto& d, auto& s0, auto& sc){ TXORS(d, s0, sc); })


### PR DESCRIPTION
迁移自内部看护套件，落位 benchmark/one-level-arch/test/solution/tileop-test/：
- 6 域 demo(vec/sfu/cube/fixp/tlsu/misc,118 case) + host 独立 golden(golden.py)
  + 共享驱动(common) + 退休隔离(retired) + README + run_guard.sh/env.sh/Makefile.common
- 四态判据(编译→执行→精度失败→精度正确) + host numpy oracle 钉 pto-spec 预期语义
- 路径适配新位置(ROOT/GUARD_ROOT/ELF_DIR),产物落 output/tileop-test(gitignore)
- env.sh 通用化(LINX_ROOT 或自设 COMPILER_DIR/GFRUN),不含任何私人绝对路径
- 不含内部 issue/report 文档

基于 upstream/main(334737e3)。已验证 build+run 与原路径逐 case 四态完全一致。