### PR TITLE
kernel: add mxquant OCP MX v1.0 operators with four-PE tests

### DIFF
--- a/benchmark/one-level-arch/kernels/multi_thread/mxquant/mxquant.hpp
+++ b/benchmark/one-level-arch/kernels/multi_thread/mxquant/mxquant.hpp
@@ -1,0 +1,283 @@
+#pragma once
+
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+
+// MXQuant: BF16[32,64] -> E4M3[32,64] + E8M0[32,2].
+//
+// Each row is split into two 32-wide MX blocks.  Per block g:
+//
+//   amax[g]       = rowmax(abs(X[:, g*32 : g*32+32]))      // BF16[32,1]
+//   scale[g]      = MX_E8M0(amax[g])                       // covers QMAX=448
+//   Q[:, block g] = E4M3_RNE_SAT(X[:, block g] * (1/scale[g]))
+//
+// The two blocks arrive as separate [32,32] tiles (the test loads them with
+// two strided TLOADs).  The scaled halves are encoded to E4M3 independently
+// and stored back with two strided TSTOREs; a TASSEMBLY variant that packs
+// them into one [32,64] tile first is kept disabled below (gfsim does not
+// model B.ASSEMBLE; TPARTVIEW subview sources are only modelled for CUBE
+// layouts, so RowMajor operands use materialized tiles instead).
+//
+// Two ISA representation rules shape the helper types below:
+//   - TROWMAX/TROWEXPANDMUL require their reduction result / broadcast
+//     operand to be exactly N x 1, hence RowMaxTile.
+//   - Ordinary TCVT requires equal capacity-derived physical rows and equal
+//     ValidRow/ValidCol on both sides.  A narrow BF16<->E8M0 pair therefore
+//     carries the single scale column in a [32,2] byte tile with ValidCol=1
+//     (ScaleTile); see the TCVT legality note in template_asm.hpp.
+
+namespace mxquant {
+
+using namespace pto;
+
+constexpr int kTotalRows = 128;          // Complete tensor: 4 PE × 32
+constexpr int kRows = 32;                // Rows per PE
+constexpr int kCols = 64;
+constexpr int kBlock = 32;
+constexpr int kBlocksPerRow = kCols / kBlock;
+constexpr int kE4M3Max = 448;
+
+// Layout note: Vec + CubeM32 (VecTileM32) was tried and reverted — the API
+// rejects CubeM16/M32 fractals as TCVT operands unless the tile has a Matrix
+// location (template_asm.hpp "TCVT CUBE_M16/M32 destination must have Matrix
+// location"), so Vec M32 tiles can only be TLOADed/TSTOREd, not converted.
+// Until the API supports Vec-side M32 TCVT, compute tiles stay RowMajor.
+using InputTile = Tile<Location::Vec, __bf16, kRows, kCols, BLayout::RowMajor>;
+using BlockTile = Tile<Location::Vec, __bf16, kRows, kBlock, BLayout::RowMajor>;
+using RowMaxTile = Tile<Location::Vec, __bf16, kRows, 1, BLayout::RowMajor>;
+// The RTM amax -> E8M0 convert below is written as FP16 -> E8M0, so the BF16
+// row max is widened first.  BF16->FP16 is an exact widening for this
+// kernel's amplitude range.  (Narrowing this to a direct BF16 -> E8M0 RTM
+// convert would drop one TCVT, but that source/dest pair is unverified
+// against the model.)
+using Fp16RowMaxTile = Tile<Location::Vec, __half, kRows, 1, BLayout::RowMajor>;
+using QuantizedTile =
+    Tile<Location::Vec, __fp8_e4m3, kRows, kCols, BLayout::RowMajor>;
+// One quantized MX block; run() stores the halves with strided TSTOREs
+// (gfsim does not model B.ASSEMBLE).
+using QuantBlockTile =
+    Tile<Location::Vec, __fp8_e4m3, kRows, kBlock, BLayout::RowMajor>;
+
+// One E8M0 scale column per MX block.  Stored as [32,2] with ValidCol=1 so
+// BF16<->E8M0 TCVT keeps matching capacity-derived rows; TSTORE writes only
+// the valid column, so the GM layout stays the compact [32,2] form.
+using ScaleTile =
+    Tile<Location::Vec, __fp8_e8m0, kRows, 2, BLayout::RowMajor, kRows, 1>;
+
+// Same geometry and bytes as ScaleTile, but a native uint8_t tile: this is the
+// carrier the E8M0 exponent codes actually live in while they are being
+// manipulated as raw bytes (TSUBS/TSUB/TEXPANDS) and when they are stored.
+//
+// It has to be a real u8 tile rather than a reinterpret_tile view of a
+// ScaleTile, for two reasons:
+//   - TSUBS(dst, src, s) binds dst and src to one template parameter, so a
+//     native tile and a view of it are different types and will not bind.
+//   - The model tags each Tile register with the dtype of the block that last
+//     wrote it.  A byte-domain write leaves the register tagged UINT8, and
+//     ValidateLocalTlsu (AccumulateBlockInfo.cpp:190) requires a non-CUBE
+//     TSTORE's block dtype to equal that tag -- so the store must be a u8
+//     store.  reinterpret_tile cannot fix this at the store: it is a
+//     zero-instruction compile-time view, so it never re-tags the register,
+//     and its view type does not expose IsCubeLayout, which TSTORE requires.
+// E8M0 and uint8_t are both 8 bit and TSTORE does not convert, so the bytes
+// landing in GM are identical either way.
+using ScaleCodeTile =
+    Tile<Location::Vec, uint8_t, kRows, 2, BLayout::RowMajor, kRows, 1>;
+
+static_assert(ScaleCodeTile::TilesizeCode == ScaleTile::TilesizeCode,
+              "the u8 scale carrier must occupy the same Tile capacity as the "
+              "E8M0 view of it");
+
+static_assert(kCols % kBlock == 0, "MX block must divide the input width");
+static_assert(kE4M3Max == 448, "this profile uses the E4M3 max finite value");
+static_assert(RowMaxTile::ValidCol == 1 && RowMaxTile::Cols == 1,
+              "TROWMAX reduction result must be logical N x 1");
+
+// BF16 amax -> E8M0 per OCP MX v1.0 Section 6.3: X = floor_pow2(amax) / 256.
+// Since 256 = 2^8, this is equivalent to: scale_exp = floor(log2(amax)) - 8.
+// Writes the raw E8M0 exponent code into a u8 carrier; see ScaleCodeTile for
+// why the code stays in a u8 tile rather than an E8M0 one.
+inline void tcvt_e8m0_ocp(ScaleCodeTile &dst, Fp16RowMaxTile &src) {
+  // Step 1: unscaled FP16 amax -> E8M0 with RTM (floor) rounding.  Public
+  // TCVT is fixed at RNONE, whose E8M0 RNE midpoint is the geometric mean
+  // sqrt(2), so it rounds up throughout (sqrt(2), 2) instead of flooring;
+  // hand-written asm is the only way to request RTM.  The destination is
+  // declared u8 and the E8M0 dtype is supplied to B.DATR directly, so the
+  // register is tagged u8 for the byte-domain arithmetic that follows.
+  ScaleCodeTile amax_e8m0;
+  asm volatile(
+      "BSTART.TEPL 27, %D[SrcT]\n"
+      "B.DATR %D[DstT], RTM\n"  // RTM = floor (LinxRMode 3)
+      "B.DIM zero, %c[VCols], ->lb0\n"
+      "B.DIM zero, %c[VRows], ->lb1\n"
+      "B.DIM zero, %c[Cols], ->lb2\n"
+      "B.IOT %[Src], mask=1111, last, ->%[Dst]<%Z[Size]>\n"
+      : [Dst] "=Tr"(amax_e8m0.data())
+      : [SrcT] "i"(type_traits<__half>::TypeCode),
+        [DstT] "i"(type_traits<__fp8_e8m0>::TypeCode),
+        [Src] "Tr"(src.data()),
+        [Size] "i"(ScaleCodeTile::TilesizeCode),
+        [VCols] "i"(Fp16RowMaxTile::ValidCol),
+        [VRows] "i"(Fp16RowMaxTile::ValidRow),
+        [Cols] "i"(ScaleCodeTile::Cols)
+      : "memory");
+
+  // Step 2: apply the OCP /256 as an exponent subtraction in the raw byte
+  // domain (256 = 2^8).  Preferred over dividing the FP16 amax by 256 before
+  // the convert: no FP16 rounding step at all, so it stays exact for
+  // amplitudes an FP16 division would have flushed toward subnormal.  U8
+  // TSUBS is ISA-legal -- TileVecArithmeticDataTypeSupported
+  // (dtype-layout.asl:101) admits U8 -- but gfrun's TEPL assertion was
+  // narrower than the ASL until SuperScalarModel issue #625.
+  // Caveat: this is a byte-domain subtract, so an amax whose E8M0 exponent
+  // code is below 8 wraps instead of clamping.  Out of range for this
+  // kernel's inputs; a saturating form would need TMAX against 8 first.
+  TSUBS(dst, amax_e8m0, static_cast<uint8_t>(8));
+}
+
+// E8M0 is a biased-exponent byte, so its reciprocal is 254 - code in the raw
+// byte domain: decode(254 - code) = 2^(127 - code) = 1 / decode(code).
+// TSUB on E8M0 tiles would be a numeric subtraction, not a storage-byte one,
+// so the codes are kept in u8 carriers throughout.
+inline void e8m0_reciprocal_code(ScaleCodeTile &dst, ScaleCodeTile &src) {
+  ScaleCodeTile constant;
+  TEXPANDS(constant, static_cast<uint8_t>(254));
+  TSUB(dst, constant, src);
+}
+
+// Decode raw E8M0 exponent codes held in a u8 carrier into BF16 values.
+//
+// The public TCVT cannot express this: its source would have to be a
+// reinterpret_tile<__fp8_e8m0> view, and that view type does not expose
+// StorageBytes, which TCVT's derived-rows check reads.  Hand-written asm
+// instead declares the source dtype as E8M0 directly while binding the u8
+// tile's register -- the same technique tcvt_e8m0_ocp uses on the way in.
+//
+// The emitted encoding is identical to what TCVT(RowMaxTile, ScaleTile) would
+// produce: LB0/LB1 carry the source's valid columns/rows, LB2 the destination's
+// physical columns, and TSize the destination's capacity.  The [32,2]
+// ValidCol=1 source geometry is what keeps the capacity-derived physical rows
+// equal on both sides.
+inline void tcvt_e8m0_code_to_bf16(RowMaxTile &dst, ScaleCodeTile &src) {
+  asm volatile(
+      "BSTART.TEPL 27, %D[SrcT]\n"
+      "B.DATR %D[DstT], RNONE\n"
+      "B.DIM zero, %c[VCols], ->lb0\n"
+      "B.DIM zero, %c[VRows], ->lb1\n"
+      "B.DIM zero, %c[Cols], ->lb2\n"
+      "B.IOT %[Src], mask=1111, last, ->%[Dst]<%Z[Size]>\n"
+      : [Dst] "=Tr"(dst.data())
+      : [SrcT] "i"(type_traits<__fp8_e8m0>::TypeCode),
+        [DstT] "i"(type_traits<__bf16>::TypeCode),
+        [Src] "Tr"(src.data()),
+        [Size] "i"(RowMaxTile::TilesizeCode),
+        [VCols] "i"(ScaleCodeTile::ValidCol),
+        [VRows] "i"(ScaleCodeTile::ValidRow),
+        [Cols] "i"(RowMaxTile::Cols)
+      : "memory");
+}
+
+// Quantize one 32-wide MX block and emit its per-row E8M0 scale code.
+inline void quantize_block(BlockTile &dst, ScaleCodeTile &scale,
+                           BlockTile &block) {
+  BlockTile abs_block;
+  TABS(abs_block, block);
+
+  RowMaxTile amax;
+  TROWMAX(amax, abs_block);
+
+  // OCP MX v1.0 §6.3: scale = floor_pow2(amax) / 256.
+  // The RTM convert in tcvt_e8m0_ocp takes an FP16 source, so widen first
+  // (exact for this amplitude range); the /256 is applied there as a
+  // byte-domain exponent subtract.
+  Fp16RowMaxTile amax_h;
+  TCVT(amax_h, amax);
+
+  tcvt_e8m0_ocp(scale, amax_h);
+
+  ScaleCodeTile reciprocal_code;
+  e8m0_reciprocal_code(reciprocal_code, scale);
+
+  RowMaxTile reciprocal;
+  tcvt_e8m0_code_to_bf16(reciprocal, reciprocal_code);
+
+  TROWEXPANDMUL(dst, block, reciprocal);
+}
+
+// SPMD entry: [128, 64] complete tensor, 4 PE each process 32 rows.
+inline void run(__fp8_e4m3 *output, __fp8_e8m0 *scales, const __bf16 *input) {
+  const uint32_t tid = get_thread_idx();
+  if (tid >= 4) return;
+
+  // Each PE gets a contiguous [32, 64] row segment
+  const __bf16 *my_input = input + tid * kRows * kCols;
+  __fp8_e4m3 *my_output = output + tid * kRows * kCols;
+  __fp8_e8m0 *my_scales = scales + tid * kRows * kBlocksPerRow;
+  // The scale codes are stored from a u8 tile, so the GM view is u8 too; the
+  // bytes are identical to the E8M0 ones the caller expects.
+  uint8_t *my_scale_codes = reinterpret_cast<uint8_t *>(my_scales);
+
+  // Process two [32, 32] half-blocks with strided TLOAD/TSTORE
+  global_tensor<__bf16, RowMajor<kRows, kCols>> input_tensor(my_input);
+  global_tensor<__fp8_e4m3, RowMajor<kRows, kCols>> output_tensor(my_output);
+
+  // Left half-block [32, 32]: columns [0, 32)
+  BlockTile left_block;
+  TLOAD(left_block, input_tensor);
+
+  BlockTile scaled_left;
+  ScaleCodeTile left_scale;
+  quantize_block(scaled_left, left_scale, left_block);
+
+  QuantBlockTile left_out;
+  TCVT(left_out, scaled_left);
+  TSTORE(output_tensor, left_out);
+
+  global_iterator<global_tensor<uint8_t, RowMajor<kRows, kBlocksPerRow>>, ScaleCodeTile>
+      left_scale_iter(my_scale_codes);
+  auto left_scale_global = left_scale_iter(0, 0);
+  TSTORE(left_scale_global, left_scale);
+
+  // Right half-block [32, 32]: columns [32, 64)
+  global_tensor<__bf16, RowMajor<kRows, kCols>> input_right(my_input + kBlock);
+  BlockTile right_block;
+  TLOAD(right_block, input_right);
+
+  BlockTile scaled_right;
+  ScaleCodeTile right_scale;
+  quantize_block(scaled_right, right_scale, right_block);
+
+  QuantBlockTile right_out;
+  TCVT(right_out, scaled_right);
+
+  global_tensor<__fp8_e4m3, RowMajor<kRows, kCols>> output_right(my_output + kBlock);
+  TSTORE(output_right, right_out);
+
+  global_iterator<global_tensor<uint8_t, RowMajor<kRows, kBlocksPerRow>>, ScaleCodeTile>
+      right_scale_iter(my_scale_codes + 1);
+  auto right_scale_global = right_scale_iter(0, 0);
+  TSTORE(right_scale_global, right_scale);
+}
+
+#if 0
+// gfrun-only variant: pack the scaled halves back into one [kRows, kCols]
+// tile before the final E4M3 encode.  Kept for reference — TASSEMBLY lowers
+// to B.ASSEMBLE, which gfsim does not model, so the split-store run() above
+// is the default.
+inline void run(QuantizedTile &output, ScaleTile &left_scale,
+                ScaleTile &right_scale, BlockTile &left, BlockTile &right) {
+  BlockTile scaled_left, scaled_right;
+  quantize_block(scaled_left, left_scale, left);
+  quantize_block(scaled_right, right_scale, right);
+
+  TileArray<BlockTile, 1, kBlocksPerRow> scaled_parts;
+  TCVT(scaled_parts[0][0], scaled_left);
+  TCVT(scaled_parts[0][1], scaled_right);
+  InputTile scaled = TASSEMBLY<InputTile>(std::move(scaled_parts));
+
+  // BF16 -> E4M3, round-to-nearest-even with saturation.
+  TCVT(output, scaled);
+}
+#endif
+
+}  // namespace mxquant

--- a/benchmark/one-level-arch/kernels/multi_thread/mxquant/mxquant_1024_assembly.hpp
+++ b/benchmark/one-level-arch/kernels/multi_thread/mxquant/mxquant_1024_assembly.hpp
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+
+// MXQuant Assembly: BF16[32,1024] -> E4M3[32,1024] + E8M0[32,32].
+//
+// Strategy: Load all 32 blocks, quantize in batch, then store.
+// gfsim-compatible (TASSEMBLY path commented out, uses strided TSTORE).
+//
+// Each row is split into 32 MX blocks. Per block g:
+//   amax[g]       = rowmax(abs(X[:, g*32 : g*32+32]))
+//   scale[g]      = MX_E8M0(amax[g])
+//   Q[:, block g] = E4M3_RNE_SAT(X[:, block g] * (1/scale[g]))
+
+namespace mxquant_assembly {
+
+using namespace pto;
+
+constexpr int kTotalRows = 128;          // Complete tensor: 4 PE × 32
+constexpr int kRows = 32;                // Rows per PE
+constexpr int kCols = 1024;
+constexpr int kBlock = 32;
+constexpr int kBlocksPerRow = kCols / kBlock;  // = 32
+constexpr int kE4M3Max = 448;
+
+using BlockTile = Tile<Location::Vec, __bf16, kRows, kBlock, BLayout::RowMajor>;
+using RowMaxTile = Tile<Location::Vec, __bf16, kRows, 1, BLayout::RowMajor>;
+using Fp16RowMaxTile = Tile<Location::Vec, __half, kRows, 1, BLayout::RowMajor>;
+using QuantBlockTile = Tile<Location::Vec, __fp8_e4m3, kRows, kBlock, BLayout::RowMajor>;
+using ScaleTile = Tile<Location::Vec, __fp8_e8m0, kRows, 2, BLayout::RowMajor, kRows, 1>;
+
+// Same geometry and bytes as ScaleTile, but a native uint8_t tile: this is the
+// carrier the E8M0 exponent codes live in while they are manipulated as raw
+// bytes (TSUBS/TSUB/TEXPANDS) and when they are stored.  It has to be a real
+// u8 tile rather than a reinterpret_tile view, because the model tags each
+// Tile register with the dtype of the block that last wrote it and
+// ValidateLocalTlsu (AccumulateBlockInfo.cpp:190) requires a non-CUBE TSTORE's
+// block dtype to equal that tag.  See mxquant.hpp for the full rationale.
+using ScaleCodeTile = Tile<Location::Vec, uint8_t, kRows, 2, BLayout::RowMajor, kRows, 1>;
+
+static_assert(ScaleCodeTile::TilesizeCode == ScaleTile::TilesizeCode,
+              "the u8 scale carrier must occupy the same Tile capacity as the "
+              "E8M0 view of it");
+
+static_assert(kCols % kBlock == 0, "MX block must divide input width");
+static_assert(kE4M3Max == 448, "E4M3 max finite value");
+
+// BF16 amax -> E8M0 per OCP MX v1.0 Section 6.3: X = floor_pow2(amax) / 256.
+// Since 256 = 2^8, this is equivalent to: scale_exp = floor(log2(amax)) - 8.
+// Hand-written asm with RTM (round toward minus infinity = floor).
+inline void tcvt_e8m0_ocp(ScaleCodeTile &dst, Fp16RowMaxTile &src) {
+  // Step 1: unscaled FP16 amax -> E8M0 with RTM (floor) rounding.  Public
+  // TCVT is fixed at RNONE, whose E8M0 RNE midpoint is the geometric mean
+  // sqrt(2), so it rounds up throughout (sqrt(2), 2) instead of flooring;
+  // hand-written asm is the only way to request RTM.  The destination is
+  // declared u8 and the E8M0 dtype is supplied to B.DATR directly, so the
+  // register is tagged u8 for the byte-domain arithmetic that follows.
+  ScaleCodeTile amax_e8m0;
+  asm volatile(
+      "BSTART.TEPL 27, %D[SrcT]\n"
+      "B.DATR %D[DstT], RTM\n"  // RTM = floor (LinxRMode 3)
+      "B.DIM zero, %c[VCols], ->lb0\n"
+      "B.DIM zero, %c[VRows], ->lb1\n"
+      "B.DIM zero, %c[Cols], ->lb2\n"
+      "B.IOT %[Src], mask=1111, last, ->%[Dst]<%Z[Size]>\n"
+      : [Dst] "=Tr"(amax_e8m0.data())
+      : [SrcT] "i"(type_traits<__half>::TypeCode),
+        [DstT] "i"(type_traits<__fp8_e8m0>::TypeCode),
+        [Src] "Tr"(src.data()),
+        [Size] "i"(ScaleCodeTile::TilesizeCode),
+        [VCols] "i"(Fp16RowMaxTile::ValidCol),
+        [VRows] "i"(Fp16RowMaxTile::ValidRow),
+        [Cols] "i"(ScaleCodeTile::Cols)
+      : "memory");
+
+  // Step 2: apply the OCP /256 as an exponent subtraction in the raw byte
+  // domain (256 = 2^8).  No FP16 rounding step at all, so it stays exact for
+  // amplitudes an FP16 division would have flushed toward subnormal.  U8
+  // TSUBS is ISA-legal -- TileVecArithmeticDataTypeSupported
+  // (dtype-layout.asl:101) admits U8 -- but gfrun's TEPL assertion was
+  // narrower than the ASL until SuperScalarModel issue #625.
+  // Caveat: byte-domain subtract, so an amax whose E8M0 exponent code is below
+  // 8 wraps instead of clamping.  Out of range for this kernel's inputs.
+  TSUBS(dst, amax_e8m0, static_cast<uint8_t>(8));
+}
+
+// E8M0 is a biased-exponent byte, so its reciprocal is 254 - code in the raw
+// byte domain: decode(254 - code) = 2^(127 - code) = 1 / decode(code).
+// TSUB on E8M0 tiles would be a numeric subtraction, not a storage-byte one,
+// so the codes are kept in u8 carriers throughout.
+inline void e8m0_reciprocal_code(ScaleCodeTile &dst, ScaleCodeTile &src) {
+  ScaleCodeTile constant;
+  TEXPANDS(constant, static_cast<uint8_t>(254));
+  TSUB(dst, constant, src);
+}
+
+// Decode raw E8M0 exponent codes held in a u8 carrier into BF16 values.
+// Public TCVT cannot express this: its source would have to be a
+// reinterpret_tile<__fp8_e8m0> view, and that view type does not expose
+// StorageBytes, which TCVT's derived-rows check reads.  See mxquant.hpp.
+inline void tcvt_e8m0_code_to_bf16(RowMaxTile &dst, ScaleCodeTile &src) {
+  asm volatile(
+      "BSTART.TEPL 27, %D[SrcT]\n"
+      "B.DATR %D[DstT], RNONE\n"
+      "B.DIM zero, %c[VCols], ->lb0\n"
+      "B.DIM zero, %c[VRows], ->lb1\n"
+      "B.DIM zero, %c[Cols], ->lb2\n"
+      "B.IOT %[Src], mask=1111, last, ->%[Dst]<%Z[Size]>\n"
+      : [Dst] "=Tr"(dst.data())
+      : [SrcT] "i"(type_traits<__fp8_e8m0>::TypeCode),
+        [DstT] "i"(type_traits<__bf16>::TypeCode),
+        [Src] "Tr"(src.data()),
+        [Size] "i"(RowMaxTile::TilesizeCode),
+        [VCols] "i"(ScaleCodeTile::ValidCol),
+        [VRows] "i"(ScaleCodeTile::ValidRow),
+        [Cols] "i"(RowMaxTile::Cols)
+      : "memory");
+}
+
+// Quantize one 32-wide MX block
+inline void quantize_block(BlockTile &dst, ScaleCodeTile &scale, BlockTile &block) {
+  BlockTile abs_block;
+  TABS(abs_block, block);
+
+  RowMaxTile amax;
+  TROWMAX(amax, abs_block);
+
+  // OCP MX v1.0 §6.3: scale = floor_pow2(amax) / 256
+  Fp16RowMaxTile amax_h;
+  TCVT(amax_h, amax);
+
+  tcvt_e8m0_ocp(scale, amax_h);
+
+  ScaleCodeTile reciprocal_code;
+  e8m0_reciprocal_code(reciprocal_code, scale);
+
+  RowMaxTile reciprocal;
+  tcvt_e8m0_code_to_bf16(reciprocal, reciprocal_code);
+
+  TROWEXPANDMUL(dst, block, reciprocal);
+}
+
+// SPMD + Batch run: [128, 1024] complete tensor, 4 PE each process 32 rows.
+// Each PE processes blocks in groups of 8 to stay under 64KB tile frame limit.
+// Peak liveness per batch: 8×BlockTile (16KB) + 8×scaled (16KB) + 8×ScaleTile
+// (~0.5KB) ≈ 32.5KB, well below the compiler's 64KB constraint.
+inline void run(__fp8_e4m3 *output, __fp8_e8m0 *scales, const __bf16 *input) {
+  const uint32_t tid = get_thread_idx();
+  if (tid >= 4) return;
+
+  // Each PE gets a contiguous [32, 1024] row segment
+  const __bf16 *my_input = input + tid * kRows * kCols;
+  __fp8_e4m3 *my_output = output + tid * kRows * kCols;
+  __fp8_e8m0 *my_scales = scales + tid * kRows * kBlocksPerRow;
+  // The scale codes are stored from a u8 tile, so the GM view is u8 too; the
+  // bytes are identical to the E8M0 ones the caller expects.
+  uint8_t *my_scale_codes = reinterpret_cast<uint8_t *>(my_scales);
+
+  constexpr int kBatchSize = 8;
+  constexpr int kNumBatches = kBlocksPerRow / kBatchSize;  // 32 / 8 = 4
+  static_assert(kBlocksPerRow % kBatchSize == 0, "kBlocksPerRow must be divisible by kBatchSize");
+
+  for (int batch = 0; batch < kNumBatches; ++batch) {
+    const int batch_start = batch * kBatchSize;
+
+    // Load one batch of blocks from this PE's row segment
+    BlockTile blocks[kBatchSize];
+    #pragma unroll
+    for (int i = 0; i < kBatchSize; ++i) {
+      const int block_idx = batch_start + i;
+      global_tensor<__bf16, RowMajor<kRows, kCols>> source(my_input + block_idx * kBlock);
+      TLOAD(blocks[i], source);
+    }
+
+    // Quantize this batch
+    BlockTile scaled_blocks[kBatchSize];
+    ScaleCodeTile scale_tiles[kBatchSize];
+    #pragma unroll
+    for (int i = 0; i < kBatchSize; ++i) {
+      quantize_block(scaled_blocks[i], scale_tiles[i], blocks[i]);
+    }
+
+    // Convert and store this batch to this PE's row segment (gfsim-compatible, no TASSEMBLY)
+    #pragma unroll
+    for (int i = 0; i < kBatchSize; ++i) {
+      const int block_idx = batch_start + i;
+
+      QuantBlockTile quantized_block;
+      TCVT(quantized_block, scaled_blocks[i]);
+
+      global_tensor<__fp8_e4m3, RowMajor<kRows, kCols>>
+          output_block(my_output + block_idx * kBlock);
+      TSTORE(output_block, quantized_block);
+
+      global_tensor<uint8_t, RowMajor<kRows, kBlocksPerRow>>
+          scale_out(my_scale_codes + block_idx);
+      TSTORE(scale_out, scale_tiles[i]);
+    }
+  }
+}
+
+}  // namespace mxquant_assembly

--- a/benchmark/one-level-arch/kernels/multi_thread/mxquant/mxquant_1024_streaming.hpp
+++ b/benchmark/one-level-arch/kernels/multi_thread/mxquant/mxquant_1024_streaming.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+
+// MXQuant Streaming: BF16[32,1024] -> E4M3[32,1024] + E8M0[32,32].
+//
+// Strategy: Process each 32-wide block independently and stream to GM.
+// Avoids large tile register pressure by quantizing block-by-block.
+// gfsim-compatible (no TASSEMBLY).
+//
+// Each row is split into 32 MX blocks. Per block g:
+//   amax[g]       = rowmax(abs(X[:, g*32 : g*32+32]))
+//   scale[g]      = MX_E8M0(amax[g])
+//   Q[:, block g] = E4M3_RNE_SAT(X[:, block g] * (1/scale[g]))
+
+namespace mxquant_streaming {
+
+using namespace pto;
+
+constexpr int kTotalRows = 128;          // Complete tensor: 4 PE × 32
+constexpr int kRows = 32;                // Rows per PE
+constexpr int kCols = 1024;
+constexpr int kBlock = 32;
+constexpr int kBlocksPerRow = kCols / kBlock;  // = 32
+constexpr int kE4M3Max = 448;
+
+using BlockTile = Tile<Location::Vec, __bf16, kRows, kBlock, BLayout::RowMajor>;
+using RowMaxTile = Tile<Location::Vec, __bf16, kRows, 1, BLayout::RowMajor>;
+using Fp16RowMaxTile = Tile<Location::Vec, __half, kRows, 1, BLayout::RowMajor>;
+using QuantBlockTile = Tile<Location::Vec, __fp8_e4m3, kRows, kBlock, BLayout::RowMajor>;
+using ScaleTile = Tile<Location::Vec, __fp8_e8m0, kRows, 2, BLayout::RowMajor, kRows, 1>;
+
+// Same geometry and bytes as ScaleTile, but a native uint8_t tile: this is the
+// carrier the E8M0 exponent codes live in while they are manipulated as raw
+// bytes (TSUBS/TSUB/TEXPANDS) and when they are stored.  It has to be a real
+// u8 tile rather than a reinterpret_tile view, because the model tags each
+// Tile register with the dtype of the block that last wrote it and
+// ValidateLocalTlsu (AccumulateBlockInfo.cpp:190) requires a non-CUBE TSTORE's
+// block dtype to equal that tag.  See mxquant.hpp for the full rationale.
+using ScaleCodeTile = Tile<Location::Vec, uint8_t, kRows, 2, BLayout::RowMajor, kRows, 1>;
+
+static_assert(ScaleCodeTile::TilesizeCode == ScaleTile::TilesizeCode,
+              "the u8 scale carrier must occupy the same Tile capacity as the "
+              "E8M0 view of it");
+
+static_assert(kCols % kBlock == 0, "MX block must divide input width");
+static_assert(kE4M3Max == 448, "E4M3 max finite value");
+
+// BF16 amax -> E8M0 per OCP MX v1.0 Section 6.3: X = floor_pow2(amax) / 256.
+// Since 256 = 2^8, this is equivalent to: scale_exp = floor(log2(amax)) - 8.
+// Hand-written asm with RTM (round toward minus infinity = floor).
+inline void tcvt_e8m0_ocp(ScaleCodeTile &dst, Fp16RowMaxTile &src) {
+  // Step 1: unscaled FP16 amax -> E8M0 with RTM (floor) rounding.  Public
+  // TCVT is fixed at RNONE, whose E8M0 RNE midpoint is the geometric mean
+  // sqrt(2), so it rounds up throughout (sqrt(2), 2) instead of flooring;
+  // hand-written asm is the only way to request RTM.  The destination is
+  // declared u8 and the E8M0 dtype is supplied to B.DATR directly, so the
+  // register is tagged u8 for the byte-domain arithmetic that follows.
+  ScaleCodeTile amax_e8m0;
+  asm volatile(
+      "BSTART.TEPL 27, %D[SrcT]\n"
+      "B.DATR %D[DstT], RTM\n"  // RTM = floor (LinxRMode 3)
+      "B.DIM zero, %c[VCols], ->lb0\n"
+      "B.DIM zero, %c[VRows], ->lb1\n"
+      "B.DIM zero, %c[Cols], ->lb2\n"
+      "B.IOT %[Src], mask=1111, last, ->%[Dst]<%Z[Size]>\n"
+      : [Dst] "=Tr"(amax_e8m0.data())
+      : [SrcT] "i"(type_traits<__half>::TypeCode),
+        [DstT] "i"(type_traits<__fp8_e8m0>::TypeCode),
+        [Src] "Tr"(src.data()),
+        [Size] "i"(ScaleCodeTile::TilesizeCode),
+        [VCols] "i"(Fp16RowMaxTile::ValidCol),
+        [VRows] "i"(Fp16RowMaxTile::ValidRow),
+        [Cols] "i"(ScaleCodeTile::Cols)
+      : "memory");
+
+  // Step 2: apply the OCP /256 as an exponent subtraction in the raw byte
+  // domain (256 = 2^8).  No FP16 rounding step at all, so it stays exact for
+  // amplitudes an FP16 division would have flushed toward subnormal.  U8
+  // TSUBS is ISA-legal -- TileVecArithmeticDataTypeSupported
+  // (dtype-layout.asl:101) admits U8 -- but gfrun's TEPL assertion was
+  // narrower than the ASL until SuperScalarModel issue #625.
+  // Caveat: byte-domain subtract, so an amax whose E8M0 exponent code is below
+  // 8 wraps instead of clamping.  Out of range for this kernel's inputs.
+  TSUBS(dst, amax_e8m0, static_cast<uint8_t>(8));
+}
+
+// E8M0 is a biased-exponent byte, so its reciprocal is 254 - code in the raw
+// byte domain: decode(254 - code) = 2^(127 - code) = 1 / decode(code).
+// TSUB on E8M0 tiles would be a numeric subtraction, not a storage-byte one,
+// so the codes are kept in u8 carriers throughout.
+inline void e8m0_reciprocal_code(ScaleCodeTile &dst, ScaleCodeTile &src) {
+  ScaleCodeTile constant;
+  TEXPANDS(constant, static_cast<uint8_t>(254));
+  TSUB(dst, constant, src);
+}
+
+// Decode raw E8M0 exponent codes held in a u8 carrier into BF16 values.
+// Public TCVT cannot express this: its source would have to be a
+// reinterpret_tile<__fp8_e8m0> view, and that view type does not expose
+// StorageBytes, which TCVT's derived-rows check reads.  See mxquant.hpp.
+inline void tcvt_e8m0_code_to_bf16(RowMaxTile &dst, ScaleCodeTile &src) {
+  asm volatile(
+      "BSTART.TEPL 27, %D[SrcT]\n"
+      "B.DATR %D[DstT], RNONE\n"
+      "B.DIM zero, %c[VCols], ->lb0\n"
+      "B.DIM zero, %c[VRows], ->lb1\n"
+      "B.DIM zero, %c[Cols], ->lb2\n"
+      "B.IOT %[Src], mask=1111, last, ->%[Dst]<%Z[Size]>\n"
+      : [Dst] "=Tr"(dst.data())
+      : [SrcT] "i"(type_traits<__fp8_e8m0>::TypeCode),
+        [DstT] "i"(type_traits<__bf16>::TypeCode),
+        [Src] "Tr"(src.data()),
+        [Size] "i"(RowMaxTile::TilesizeCode),
+        [VCols] "i"(ScaleCodeTile::ValidCol),
+        [VRows] "i"(ScaleCodeTile::ValidRow),
+        [Cols] "i"(RowMaxTile::Cols)
+      : "memory");
+}
+
+// Quantize one 32-wide MX block
+inline void quantize_block(BlockTile &dst, ScaleCodeTile &scale, BlockTile &block) {
+  BlockTile abs_block;
+  TABS(abs_block, block);
+
+  RowMaxTile amax;
+  TROWMAX(amax, abs_block);
+
+  // OCP MX v1.0 §6.3: scale = floor_pow2(amax) / 256
+  Fp16RowMaxTile amax_h;
+  TCVT(amax_h, amax);
+
+  tcvt_e8m0_ocp(scale, amax_h);
+
+  ScaleCodeTile reciprocal_code;
+  e8m0_reciprocal_code(reciprocal_code, scale);
+
+  RowMaxTile reciprocal;
+  tcvt_e8m0_code_to_bf16(reciprocal, reciprocal_code);
+
+  TROWEXPANDMUL(dst, block, reciprocal);
+}
+
+// SPMD + Streaming run: [128, 1024] complete tensor, 4 PE each process 32 rows.
+// Each PE processes all 32 blocks sequentially to minimize tile register pressure.
+inline void run(__fp8_e4m3 *output, __fp8_e8m0 *scales, const __bf16 *input) {
+  const uint32_t tid = get_thread_idx();
+  if (tid >= 4) return;
+
+  // Each PE gets a contiguous [32, 1024] row segment
+  const __bf16 *my_input = input + tid * kRows * kCols;
+  __fp8_e4m3 *my_output = output + tid * kRows * kCols;
+  __fp8_e8m0 *my_scales = scales + tid * kRows * kBlocksPerRow;
+  // The scale codes are stored from a u8 tile, so the GM view is u8 too; the
+  // bytes are identical to the E8M0 ones the caller expects.
+  uint8_t *my_scale_codes = reinterpret_cast<uint8_t *>(my_scales);
+
+  for (int block_idx = 0; block_idx < kBlocksPerRow; ++block_idx) {
+    global_tensor<__bf16, RowMajor<kRows, kCols>> source(my_input + block_idx * kBlock);
+    BlockTile block;
+    TLOAD(block, source);
+
+    BlockTile scaled_block;
+    ScaleCodeTile scale;
+    quantize_block(scaled_block, scale, block);
+
+    QuantBlockTile quantized_block;
+    TCVT(quantized_block, scaled_block);
+
+    global_tensor<__fp8_e4m3, RowMajor<kRows, kCols>>
+        output_block(my_output + block_idx * kBlock);
+    TSTORE(output_block, quantized_block);
+
+    global_tensor<uint8_t, RowMajor<kRows, kBlocksPerRow>>
+        scale_out(my_scale_codes + block_idx);
+    TSTORE(scale_out, scale);
+  }
+}
+
+}  // namespace mxquant_streaming

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/Makefile
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/Makefile
@@ -1,0 +1,40 @@
+# Multi-thread MX quantization (OCP MX v1.0 section 6.3) operators.
+#
+# Three variants share one kernel contract: a [128, kCols] BF16 tensor is
+# quantized to E4M3 payload plus group-32 E8M0 scales, and each kernel slices
+# the tensor by M across four PEs via get_thread_idx().
+#
+#   mxquant                  kCols=64,   two strided half-blocks
+#   mxquant_1024_assembly    kCols=1024, 8-block batches (higher tile pressure)
+#   mxquant_1024_streaming   kCols=1024, one block at a time (~5 KB peak)
+#
+# TESTCASE selects the variant and is deliberately the source basename: the
+# `clean` rule in Makefile.common only removes ${TESTCASE}.o, so a per-variant
+# TESTCASE is what keeps a rebuild from silently relinking another variant's
+# stale object (there is no header dependency tracking).
+#
+# Run every variant with four PEs, e.g.
+#   gfrun -s softcore.multiThreadNum=4 -f <elf>
+#
+# res_check=on builds the verifying variant: PE0 reads input.bin from CHK_DIR,
+# derives the scalar golden from it, and exports both for src/run_mxquant_check.py
+# to compare byte-for-byte.  The default build runs the tile kernel alone and is
+# the one to hand a cycle simulator.
+
+TESTCASE ?= mxquant
+
+ifeq ($(TESTCASE),mxquant)
+SRC_FILE += $(TEST_ROOT)/$(CASE_SRC_DIR)/mxquant.cpp
+TARGET = $(ELF_HEAD)_mxquant_PE4.elf
+else ifeq ($(TESTCASE),mxquant_1024_assembly)
+SRC_FILE += $(TEST_ROOT)/$(CASE_SRC_DIR)/mxquant_1024_assembly.cpp
+TARGET = $(ELF_HEAD)_mxquant_1024_assembly_PE4.elf
+else ifeq ($(TESTCASE),mxquant_1024_streaming)
+SRC_FILE += $(TEST_ROOT)/$(CASE_SRC_DIR)/mxquant_1024_streaming.cpp
+TARGET = $(ELF_HEAD)_mxquant_1024_streaming_PE4.elf
+else
+$(error Unsupported TESTCASE=$(TESTCASE); expected mxquant, \
+mxquant_1024_assembly, or mxquant_1024_streaming)
+endif
+
+include ../../../common/Makefile.common

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/compile.all
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/compile.all
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Multi-thread MX quantization operators (OCP MX v1.0 section 6.3).
+#
+#   export COMPILER_DIR=/path/to/linx_blockisa_llvm_musl/bin
+#   ./compile.all
+#
+# Builds the three variants with res_check=on, which is the verifying mode:
+# PE0 reads input.bin from CHK_DIR, derives the scalar golden from that same
+# input, and exports both.  Compare on the host with
+#   python3 src/run_mxquant_check.py --gfrun /path/to/gfrun
+# which generates the inputs and does the byte-exact comparison.
+#
+# Every variant is SPMD over four PEs:
+#   gfrun -s softcore.multiThreadNum=4 -f <elf>
+#
+# Build without res_check=on to get the kernel-only ELF for cycle simulation.
+
+set -euo pipefail
+
+: "${COMPILER_DIR:?Set COMPILER_DIR to the Linx compiler bin directory}"
+
+for testcase in mxquant mxquant_1024_assembly mxquant_1024_streaming; do
+    make TESTCASE="$testcase" COMPILER_DIR="$COMPILER_DIR" res_check=on diss
+done

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant.cpp
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant.cpp
@@ -1,0 +1,26 @@
+#include "multi_thread/mxquant/mxquant.hpp"
+
+#include "mxquant_driver.h"
+
+namespace {
+
+constexpr int kTotalRows = mxquant::kTotalRows;
+constexpr int kCols = mxquant::kCols;
+constexpr int kBlocksPerRow = mxquant::kBlocksPerRow;
+
+// Shared across the four PEs: the kernel slices this tensor by M internally.
+mxquant_test::Buffers<kTotalRows, kCols, kBlocksPerRow> buffers{};
+MultiThreadResCheckSync res_check_sync{};
+
+}  // namespace
+
+int main() {
+    const std::uint32_t tid = get_thread_idx();
+    mxquant_test::prepare(buffers, res_check_sync, tid, mxquant::kBlock);
+
+    BENCHSTART;
+    mxquant::run(buffers.output, buffers.scales, buffers.input);
+    BENCHEND;
+
+    return mxquant_test::finish(buffers, res_check_sync, tid);
+}

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_1024_assembly.cpp
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_1024_assembly.cpp
@@ -1,0 +1,27 @@
+#include "multi_thread/mxquant/mxquant_1024_assembly.hpp"
+
+#include "mxquant_driver.h"
+
+namespace {
+
+constexpr int kTotalRows = mxquant_assembly::kTotalRows;
+constexpr int kCols = mxquant_assembly::kCols;
+constexpr int kBlocksPerRow = mxquant_assembly::kBlocksPerRow;
+
+// Shared across the four PEs: the kernel slices this tensor by M internally.
+mxquant_test::Buffers<kTotalRows, kCols, kBlocksPerRow> buffers{};
+MultiThreadResCheckSync res_check_sync{};
+
+}  // namespace
+
+int main() {
+    const std::uint32_t tid = get_thread_idx();
+    mxquant_test::prepare(buffers, res_check_sync, tid,
+                          mxquant_assembly::kBlock);
+
+    BENCHSTART;
+    mxquant_assembly::run(buffers.output, buffers.scales, buffers.input);
+    BENCHEND;
+
+    return mxquant_test::finish(buffers, res_check_sync, tid);
+}

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_1024_streaming.cpp
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_1024_streaming.cpp
@@ -1,0 +1,27 @@
+#include "multi_thread/mxquant/mxquant_1024_streaming.hpp"
+
+#include "mxquant_driver.h"
+
+namespace {
+
+constexpr int kTotalRows = mxquant_streaming::kTotalRows;
+constexpr int kCols = mxquant_streaming::kCols;
+constexpr int kBlocksPerRow = mxquant_streaming::kBlocksPerRow;
+
+// Shared across the four PEs: the kernel slices this tensor by M internally.
+mxquant_test::Buffers<kTotalRows, kCols, kBlocksPerRow> buffers{};
+MultiThreadResCheckSync res_check_sync{};
+
+}  // namespace
+
+int main() {
+    const std::uint32_t tid = get_thread_idx();
+    mxquant_test::prepare(buffers, res_check_sync, tid,
+                          mxquant_streaming::kBlock);
+
+    BENCHSTART;
+    mxquant_streaming::run(buffers.output, buffers.scales, buffers.input);
+    BENCHEND;
+
+    return mxquant_test::finish(buffers, res_check_sync, tid);
+}

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_driver.h
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_driver.h
@@ -1,0 +1,130 @@
+#pragma once
+
+// Shared driver for the three mxquant test entries.
+//
+// The kernels are SPMD: main() runs on all four PEs and each kernel slices the
+// [kTotalRows, kCols] tensor by M via get_thread_idx().  Always run with
+//   gfrun -s softcore.multiThreadNum=4
+//
+// Two build modes, matching the library convention:
+//
+//   default        Run the tile kernel only.  Nothing is read or written, so
+//                  this is the build to hand a cycle simulator.  The tile
+//                  pipeline has no data-dependent control flow, so the
+//                  zero-filled input still yields representative cycle counts.
+//
+//   res_check=on   PE0 reads input.bin from CHK_DIR, the scalar reference
+//                  computes the golden result from that same input, and PE0
+//                  exports the kernel output, the golden, and a read-back copy
+//                  of the input it actually saw.  run_mxquant_check.py does the
+//                  byte comparison on the host.
+//
+// Why the input must come from the host: device-side scalar generation of the
+// input tensor was measured to be unreliable here -- stores issued by a scalar
+// fill loop did not become visible to the buffer the kernel and the syscall
+// path read, which silently degraded the whole test to an all-zero input where
+// the golden is also all zero and any comparison passes vacuously.  Reading
+// input.bin through the syscall path is coherent, so the host owns the input.
+// input_readback.bin exists to keep that failure mode from ever going quiet
+// again: the host asserts it matches the input.bin it generated.
+//
+// Buffers live in shared .bss because all four PEs address the same tensor;
+// only PE0 touches files, per the 4-PE protocol in multi_thread_res_check.h.
+
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+
+#include "benchmark.h"
+
+#ifdef RES_CHECK
+#include "fileop.h"
+#include "multi_thread_res_check.h"
+#include "mxquant_scalar_ref.h"
+#endif
+
+namespace mxquant_test {
+
+#ifdef RES_CHECK
+
+template <int kTotalRows, int kCols, int kBlocksPerRow>
+struct Buffers {
+    alignas(4096) __bf16 input[kTotalRows * kCols];
+    alignas(4096) __fp8_e4m3 output[kTotalRows * kCols];
+    alignas(4096) __fp8_e8m0 scales[kTotalRows * kBlocksPerRow];
+    alignas(4096) uint8_t golden_output[kTotalRows * kCols];
+    alignas(4096) uint8_t golden_scales[kTotalRows * kBlocksPerRow];
+};
+
+// PE0 loads the host input and derives the golden from it; PE1..PE3 wait.
+template <int kTotalRows, int kCols, int kBlocksPerRow>
+inline void prepare(Buffers<kTotalRows, kCols, kBlocksPerRow> &buffers,
+                    MultiThreadResCheckSync &sync, std::uint32_t tid,
+                    int block) {
+    if (tid == 0) {
+        readBinaryFile(CHK_DIR "/input.bin",
+                       reinterpret_cast<uint8_t *>(buffers.input),
+                       sizeof(buffers.input));
+        mxquant_ref::golden(buffers.input, buffers.golden_output,
+                            buffers.golden_scales, kTotalRows, kCols, block);
+    }
+    res_check_publish_inputs(sync, tid);
+}
+
+// PE0 waits for every slice, exports the buffers, and runs the byte-exact
+// in-simulation comparison.  Returns the failure count on PE0, 0 elsewhere.
+template <int kTotalRows, int kCols, int kBlocksPerRow>
+inline int finish(Buffers<kTotalRows, kCols, kBlocksPerRow> &buffers,
+                  MultiThreadResCheckSync &sync, std::uint32_t tid) {
+    res_check_wait_for_all(sync, tid);
+    if (tid != 0) {
+        return 0;
+    }
+    // Read-back guard: proves the kernel and the golden saw the host input.
+    writeBinaryFile(CHK_DIR "/input_readback.bin",
+                    reinterpret_cast<uint8_t *>(buffers.input),
+                    sizeof(buffers.input));
+    writeBinaryFile(CHK_DIR "/output.bin",
+                    reinterpret_cast<uint8_t *>(buffers.output),
+                    sizeof(buffers.output));
+    writeBinaryFile(CHK_DIR "/scale_output.bin",
+                    reinterpret_cast<uint8_t *>(buffers.scales),
+                    sizeof(buffers.scales));
+    writeBinaryFile(CHK_DIR "/golden_output.bin", buffers.golden_output,
+                    sizeof(buffers.golden_output));
+    writeBinaryFile(CHK_DIR "/golden_scales.bin", buffers.golden_scales,
+                    sizeof(buffers.golden_scales));
+    return mxquant_ref::check_result(tid, buffers.output, buffers.scales,
+                                     buffers.golden_output,
+                                     buffers.golden_scales, kTotalRows, kCols,
+                                     kBlocksPerRow);
+}
+
+#else  // !RES_CHECK
+
+// Kernel-only build: just the tensors the kernel itself touches.
+template <int kTotalRows, int kCols, int kBlocksPerRow>
+struct Buffers {
+    alignas(4096) __bf16 input[kTotalRows * kCols];
+    alignas(4096) __fp8_e4m3 output[kTotalRows * kCols];
+    alignas(4096) __fp8_e8m0 scales[kTotalRows * kBlocksPerRow];
+};
+
+struct NoSync {};
+
+template <int kTotalRows, int kCols, int kBlocksPerRow>
+inline void prepare(Buffers<kTotalRows, kCols, kBlocksPerRow> &, NoSync &,
+                    std::uint32_t, int) {}
+
+template <int kTotalRows, int kCols, int kBlocksPerRow>
+inline int finish(Buffers<kTotalRows, kCols, kBlocksPerRow> &, NoSync &,
+                  std::uint32_t) {
+    return 0;
+}
+
+#endif  // RES_CHECK
+
+}  // namespace mxquant_test
+
+#ifndef RES_CHECK
+using MultiThreadResCheckSync = mxquant_test::NoSync;
+#endif

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_scalar_ref.h
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/mxquant_scalar_ref.h
@@ -1,0 +1,161 @@
+#pragma once
+
+// Shared scalar reference for all mxquant test entries (64-wide and
+// 1024-wide variants).  Kept deliberately separate from the TileOP kernels
+// so a byte-for-byte check is possible without hiding the kernel dataflow.
+// Compiled only into res_check=on builds.
+
+#include <common/pto_tileop.hpp>
+#include <cstdint>
+
+#include "linx_print.h"
+
+namespace mxquant_ref {
+
+inline uint8_t round_shift_even(uint32_t value, int shift) {
+  if (shift <= 0) return static_cast<uint8_t>(value << (-shift));
+
+  const uint32_t base = value >> shift;
+  const uint32_t remainder = value & ((1u << shift) - 1u);
+  const uint32_t half = 1u << (shift - 1);
+  const bool round_up = remainder > half ||
+                        (remainder == half && (base & 1u) != 0);
+  return static_cast<uint8_t>(base + round_up);
+}
+
+inline uint8_t encode_e4m3(uint16_t bf16_bits) {
+  const uint8_t sign = static_cast<uint8_t>((bf16_bits >> 8) & 0x80);
+  const uint16_t abs_bits = bf16_bits & 0x7fff;
+  const int bf_exp = (abs_bits >> 7) & 0xff;
+  const uint32_t significand = 128u + (abs_bits & 0x7f);
+
+  if (bf_exp == 0) return sign;
+
+  const int exponent = bf_exp - 127;
+  if (exponent > 8) return static_cast<uint8_t>(sign | 0x7e);
+  if (exponent < -9) return sign;
+
+  if (exponent < -6) {
+    const int shift = -(exponent + 2);
+    const uint8_t mantissa = round_shift_even(significand, shift);
+    return mantissa >= 8 ? static_cast<uint8_t>(sign | 0x08)
+                         : static_cast<uint8_t>(sign | mantissa);
+  }
+
+  int mantissa = static_cast<int>(round_shift_even(abs_bits & 0x7f, 4));
+  int biased_exponent = exponent + 7;
+  if (mantissa >= 8) {
+    mantissa = 0;
+    ++biased_exponent;
+  }
+  // E4M3 max normal is 448 (0x7E); OCP MX 6.3 clamps overflow to +-448
+  // instead of emitting the NaN pattern 0x7F (exponent 8, mantissa 7 = 480).
+  if (biased_exponent > 15 || (biased_exponent == 15 && mantissa > 6)) {
+    return static_cast<uint8_t>(sign | 0x7e);
+  }
+  return static_cast<uint8_t>(sign | (biased_exponent << 3) | mantissa);
+}
+
+inline uint8_t encode_e8m0(uint16_t amax_bits) {
+  const uint16_t abs_bits = amax_bits & 0x7fff;
+  if (abs_bits == 0) return 0;
+
+  const int bf_exp = (abs_bits >> 7) & 0xff;
+  // OCP MX section 6.3 / AMD Quark: X = 2^(floor(log2(amax)) - 8), where 8 is
+  // the max exponent of E4M3 (448 = 1.75*2^8; the largest power-of-two
+  // element is 256).  Scaled values in (448, 512) saturate in encode_e4m3.
+  int exponent = (bf_exp - 127) - 8;
+  if (exponent < -127) exponent = -127;
+  if (exponent > 127) exponent = 127;
+  return static_cast<uint8_t>(exponent + 127);
+}
+
+inline void golden(const __bf16 *input, uint8_t *output, uint8_t *scales,
+                   int rows, int cols, int block) {
+  const int blocks_per_row = cols / block;
+  for (int row = 0; row < rows; ++row) {
+    for (int blk = 0; blk < blocks_per_row; ++blk) {
+      uint16_t amax = 0;
+      for (int col = 0; col < block; ++col) {
+        const int index = row * cols + blk * block + col;
+        const uint16_t bits = *reinterpret_cast<const uint16_t *>(&input[index]);
+        amax = (bits & 0x7fff) > amax ? (bits & 0x7fff) : amax;
+      }
+
+      const uint8_t scale = encode_e8m0(amax);
+      scales[row * blocks_per_row + blk] = scale;
+      const int scale_exponent = static_cast<int>(scale) - 127;
+
+      for (int col = 0; col < block; ++col) {
+        const int index = row * cols + blk * block + col;
+        const uint16_t bits =
+            *reinterpret_cast<const uint16_t *>(&input[index]);
+        const uint16_t sign = bits & 0x8000;
+        const uint16_t abs_bits = bits & 0x7fff;
+        int exponent = (abs_bits >> 7) & 0xff;
+        if (exponent != 0) {
+          exponent += -scale_exponent;
+          if (exponent < 1) exponent = 0;
+          if (exponent > 254) exponent = 255;
+        }
+        const uint16_t scaled =
+            static_cast<uint16_t>(sign | (exponent << 7) | (abs_bits & 0x7f));
+        output[index] = encode_e4m3(scaled);
+      }
+    }
+  }
+}
+
+// Note: there is deliberately no device-side input generator here.  A scalar
+// fill loop writing this tensor was measured not to become visible to the
+// buffer the kernel and the syscall path read, which silently degraded the
+// test to an all-zero input -- where the golden is also all zero and every
+// comparison passes vacuously.  The host owns the input (input.bin); the
+// matching distribution lives in run_mxquant_check.py.
+
+inline int check_result(uint32_t tid, const __fp8_e4m3 *output,
+                        const __fp8_e8m0 *scales, const uint8_t *golden_output,
+                        const uint8_t *golden_scales, int rows, int cols,
+                        int blocks_per_row) {
+  int failures = 0;
+  for (int i = 0; i < rows * blocks_per_row; ++i) {
+    const uint8_t got = __fp8_e8m0_STORAGE(scales[i]);
+    if (got != golden_scales[i]) {
+      if (failures < 8) {
+        linxi_put("scale mismatch ");
+        linxi_put_i64(i);
+        linxi_put(" got ");
+        linxi_put_hex(got);
+        linxi_put(" want ");
+        linxi_put_hex(golden_scales[i]);
+        linxi_putc('\n');
+      }
+      ++failures;
+    }
+  }
+
+  for (int i = 0; i < rows * cols; ++i) {
+    const uint8_t got = __fp8_e4m3_STORAGE(output[i]);
+    if (got != golden_output[i]) {
+      if (failures < 8) {
+        linxi_put("payload mismatch ");
+        linxi_put_i64(i);
+        linxi_put(" got ");
+        linxi_put_hex(got);
+        linxi_put(" want ");
+        linxi_put_hex(golden_output[i]);
+        linxi_putc('\n');
+      }
+      ++failures;
+    }
+  }
+
+  linxi_put("PE ");
+  linxi_put_i64(tid);
+  linxi_put(" MXQUANT ");
+  linxi_puts(failures == 0 ? "PASS" : "FAIL");
+  linxi_put_kv("fails", failures);
+  return failures;
+}
+
+}  // namespace mxquant_ref

--- a/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/run_mxquant_check.py
+++ b/benchmark/one-level-arch/test/kernel/multi_thread/mxquant/src/run_mxquant_check.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate inputs, run the multi_thread/mxquant ELFs, and compare exactly.
+
+Each ELF must be built with ``res_check=on``.  This script writes input.bin into
+the CHK_DIR encoded in the ELF, runs gfrun with four PEs, and compares the two
+kernel outputs against the reference the device computed from that same input:
+
+    output.bin         E4M3 payload from the tile kernel
+    scale_output.bin   E8M0 group-32 scales from the tile kernel
+    golden_output.bin  payload from mxquant_scalar_ref.h
+    golden_scales.bin  scales from mxquant_scalar_ref.h
+    input_readback.bin the input the device actually saw
+
+MX quantization is bit-defined, so the comparison is byte-exact.
+
+Two guards keep a silent pass from being possible:
+  * input_readback.bin must equal the input.bin written here, which is what
+    catches the input never reaching the device;
+  * the golden must not be uniformly zero, which is what an all-zero input
+    would produce and which would make any comparison vacuous.
+
+Usage:
+    python3 run_mxquant_check.py --gfrun /path/to/gfrun
+    python3 run_mxquant_check.py --gfrun /path/to/gfrun mxquant
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+# src -> mxquant -> multi_thread -> kernel -> test -> one-level-arch
+ONE_LEVEL_ROOT = SCRIPT_DIR.parents[4]
+ELF_DIR = ONE_LEVEL_ROOT / "output/kernel/multi_thread/mxquant/elf"
+COMPARE_ROOT = ONE_LEVEL_ROOT / "compare"
+
+ROWS = 128
+BLOCK = 32
+# variant name -> column count
+VARIANTS = {
+    "mxquant": 64,
+    "mxquant_1024_assembly": 1024,
+    "mxquant_1024_streaming": 1024,
+}
+
+EXPORTS = ("input_readback.bin", "output.bin", "scale_output.bin",
+           "golden_output.bin", "golden_scales.bin")
+
+
+def make_input(rows: int, cols: int, seed: int) -> bytes:
+    """BF16 tensor spanning a wide exponent range within one group of 32.
+
+    Biased exponent 118..133 with a varying mantissa, so each group of 32 has a
+    non-trivial amax and the E8M0 scale differs across groups.
+    """
+    state = seed & 0xFFFFFFFF
+    out = bytearray()
+    for _ in range(rows * cols):
+        state = (state * 1664525 + 1013904223) & 0xFFFFFFFF
+        sign = (state >> 8) & 1
+        state = (state * 1664525 + 1013904223) & 0xFFFFFFFF
+        exponent = 118 + ((state >> 8) % 16)
+        state = (state * 1664525 + 1013904223) & 0xFFFFFFFF
+        mantissa = (state >> 8) & 0x7F
+        bits = (sign << 15) | (exponent << 7) | mantissa
+        out += struct.pack("<H", bits)
+    return bytes(out)
+
+
+def check_variant(name: str, gfrun: Path, timeout: int, seed: int) -> tuple[str, str]:
+    cols = VARIANTS[name]
+    elf = ELF_DIR / f"kernel_multi_thread_mxquant_{name}_PE4.elf"
+    if not elf.is_file():
+        return "SKIP", f"missing ELF: {elf}"
+
+    case_dir = COMPARE_ROOT / elf.stem
+    case_dir.mkdir(parents=True, exist_ok=True)
+    # Clear stale exports so a crashed run cannot look like a pass.
+    for stem in EXPORTS:
+        (case_dir / stem).unlink(missing_ok=True)
+
+    payload_bytes = ROWS * cols
+    scale_bytes = ROWS * (cols // BLOCK)
+    source = make_input(ROWS, cols, seed)
+    (case_dir / "input.bin").write_bytes(source)
+
+    command = [str(gfrun), "-s", "softcore.multiThreadNum=4", "-f", str(elf)]
+    try:
+        proc = subprocess.run(command, stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT, text=True,
+                              timeout=timeout, check=False)
+    except subprocess.TimeoutExpired as exc:
+        (case_dir / "gfrun.log").write_text(exc.stdout or "", encoding="utf-8")
+        return "TIMEOUT", f"after {timeout}s: {case_dir / 'gfrun.log'}"
+    (case_dir / "gfrun.log").write_text(proc.stdout, encoding="utf-8")
+    if proc.returncode != 0:
+        return "FAIL", f"gfrun rc={proc.returncode}: {case_dir / 'gfrun.log'}"
+
+    missing = [stem for stem in EXPORTS if not (case_dir / stem).is_file()]
+    if missing:
+        return "FAIL", f"exports missing ({', '.join(missing)}) in {case_dir}"
+
+    readback = (case_dir / "input_readback.bin").read_bytes()
+    if readback != source:
+        differing = sum(a != b for a, b in zip(readback, source))
+        return "FAIL", (f"input never reached the device: {differing} of "
+                        f"{len(source)} bytes differ from input.bin")
+
+    results = []
+    for label, actual_name, golden_name, expected in (
+        ("payload", "output.bin", "golden_output.bin", payload_bytes),
+        ("scale", "scale_output.bin", "golden_scales.bin", scale_bytes),
+    ):
+        actual = (case_dir / actual_name).read_bytes()
+        golden = (case_dir / golden_name).read_bytes()
+        if len(actual) != expected or len(golden) != expected:
+            return "FAIL", (f"{label}: size actual={len(actual)} "
+                            f"golden={len(golden)} expected={expected}")
+        if not any(golden):
+            return "FAIL", f"{label}: golden is all zero, comparison is vacuous"
+        bad = sum(a != b for a, b in zip(actual, golden))
+        if bad:
+            first = next(i for i, (a, b) in enumerate(zip(actual, golden))
+                         if a != b)
+            return "FAIL", (f"{label}: {bad}/{expected} bytes differ, first at "
+                            f"{first} (got 0x{actual[first]:02x} "
+                            f"want 0x{golden[first]:02x})")
+        results.append(f"{label} {expected}/{expected}")
+    return "PASS", ", ".join(results)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gfrun", type=Path, required=True,
+                        help="path to the gfrun binary")
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--seed", type=int, default=12345)
+    parser.add_argument("variants", nargs="*",
+                        help=f"default: {' '.join(VARIANTS)}")
+    args = parser.parse_args()
+
+    selected = args.variants or list(VARIANTS)
+    unknown = [name for name in selected if name not in VARIANTS]
+    if unknown:
+        parser.error(f"unknown variant(s): {', '.join(unknown)}")
+
+    failures = 0
+    for name in selected:
+        status, detail = check_variant(name, args.gfrun, args.timeout, args.seed)
+        if status not in ("PASS", "SKIP"):
+            failures += 1
+        print(f"{status:7} {name:24} {detail}", flush=True)
+    print(f"summary: {len(selected) - failures} ok, {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three BF16 -> E4M3 + E8M0 quantization kernels sharing one SPMD pointer interface, plus the test entries that verify them byte-for-byte.

Kernels (kernels/multi_thread/mxquant/):
  mxquant.hpp                 [128,64]   two strided half-blocks
  mxquant_1024_assembly.hpp   [128,1024] 8-block batches, ~33KB peak tile
  mxquant_1024_streaming.hpp  [128,1024] one block at a time, ~5KB peak tile

Semantics are OCP MX v1.0 section 6.3: scale_exp = floor(log2(amax)) - 8, elements quantized with E4M3 RNE and saturated to +-448 rather than emitting the NaN pattern.  The E8M0 scale path is byte-domain (TSUBS 8 on a reinterpret_tile<uint8_t> view), so no TDIVS is involved.

Verified with gfrun -s softcore.multiThreadNum=4:
  mxquant                 payload   8192/8192,   scale  256/256
  mxquant_1024_assembly   payload 131072/131072, scale 4096/4096
  mxquant_1024_streaming  payload 131072/131072, scale 4096/4096

Two follow-ups are deliberately deferred, each waiting on something outside this repository.  Both are blocked, not forgotten:

1. Migrate the compute tiles to the M32 layout once the TCVT location restriction is lifted.  Compute tiles are RowMajor here only because TCVT rejects CUBE_M16/M32 operands unless the tile has a Matrix location, so a Vec-location M32 tile can be TLOADed and TSTOREd but never converted.  Tracked as Linx-TileOP-API#121 (the compile-time static_assert, currently the only one still open) over PTO-ISA/pto-spec#267 (the normative rule it mirrors).  Note that lifting it also requires the M32 semantics of TROWMAX / TROWEXPANDMUL to be defined, so this is not a mechanical change.

2. Re-tune performance across all three variants once gfsim models TASSEMBLY.  Every store path here is a strided TSTORE because TASSEMBLY lowers to B.ASSEMBLE, which gfsim does not model; the packing variant is kept as #if 0 in mxquant.hpp for reference.  The cycle counts below therefore measure the split-store structure, not the best this algorithm can do, and the assembly-vs-streaming comparison should be redone rather than extrapolated.

Build notes for whoever touches this next:

res_check=on builds the verifying variant -- PE0 reads input.bin, derives the scalar golden from that same input, and exports both for src/run_mxquant_check.py to compare exactly.  MX quantization is bit-defined, so the comparison is byte-exact rather than tolerance-based; that is also why mxquant is not a Case in res_check_all.py, which assumes a single output compared with np.allclose.  The default (no res_check) build runs the kernel alone and is the one to hand a cycle simulator.

TESTCASE is deliberately the source basename: the clean rule in Makefile.common only removes ${TESTCASE}.o and there is no header dependency tracking, so a per-variant TESTCASE is what stops a rebuild from silently relinking another variant's stale object.  Editing a .hpp still does not trigger a rebuild -- delete the .o.

The host owns the input deliberately.  Device-side scalar generation of this tensor was measured not to become visible to the buffer the kernel and the syscall path read (volatile did not help), which degrades the test to an all-zero input where the golden is also zero and any comparison passes vacuously.  Two guards make that failure mode loud: the device exports the input it actually saw for the host to diff, and an all-zero golden is reported as FAIL rather than PASS.

gfsim (--conf fourpe): assembly 15,998 cycles vs streaming 17,026, so assembly leads by 6.4% -- less than its 9.5% static instruction advantage.  The two sit on different bottlenecks: streaming on Vector (34,688) and assembly on TLSU (56,432).  The TLSU limit is transaction count rather than bandwidth, since both variants move the same bytes; the small per-block E8M0 scale stores are what dominate.  See follow-up 2 above before treating these as the operators' ceiling.