### PR TITLE
fix(normalization): correct default compare directories

### DIFF
--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/gen_group_norm_grad_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/gen_group_norm_grad_data.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_group_norm_grad_group_norm_grad"
     "_DType__half_N32_C16_G8_HxW8192_PE4"

--- a/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/group_norm_grad_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/group_norm_grad/src/group_norm_grad_data_compare.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_group_norm_grad_group_norm_grad"
     "_DType__half_N32_C16_G8_HxW8192_PE4"

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/gen_rms_norm_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/gen_rms_norm_data.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_rms_norm_DType__half_gA512_gR8192_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/rms_norm_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm/src/rms_norm_data_compare.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_rms_norm_DType__half_gA512_gR8192_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/gen_rms_norm_binary_data.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/gen_rms_norm_binary_data.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_binary_rms_norm_binary_DType__half_gA16_gR16384_PE4"
 )

--- a/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/rms_norm_binary_data_compare.py
+++ b/benchmark/one-level-arch/test/solution/normalization/rms_norm_binary/src/rms_norm_binary_data_compare.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_CMP_DIR = (
-    SCRIPT_DIR.parents[5]
+    SCRIPT_DIR.parents[4]
     / "compare"
     / "solution_normalization_rms_norm_binary_rms_norm_binary_DType__half_gA16_gR16384_PE4"
 )


### PR DESCRIPTION
## Summary
- fix the default compare root for GroupNormGrad data generation and comparison
- fix the same path level for RMSNorm and RMSNormBinary helpers
- preserve the current main-branch testcase names and shapes

## Problem
The scripts used SCRIPT_DIR.parents[5], which resolves to benchmark/compare. The one-level validation artifacts are stored under benchmark/one-level-arch/compare, resolved by parents[4]. Without an explicit --cmp-dir, generation and comparison therefore used the wrong directory.

## Validation
- python3 -m py_compile on all six modified scripts
- verified parents[4] resolves to one-level-arch
- git diff --check